### PR TITLE
Add missing directives

### DIFF
--- a/SubjectRequirementsForConfig.txt
+++ b/SubjectRequirementsForConfig.txt
@@ -4,12 +4,14 @@
 # Subject
 1. choose port and host for each server
 	- server.listen
-	- default: 0.0.0.0:8000
+	- default: *:8000
+	- multiple: yes
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#listen
 
 2. setup server_names or not
 	- server.server_name
 	- default: ""
+	- multiple: yes
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#server_name
 
 3. the first server for a host:port will be the default for this host:port (that means it will answer to all the requests that don't belong to an other server).
@@ -18,48 +20,61 @@
 4. setup default error pages
 	- {http,server,location}.error_page
 	- default: none
+	- multiple: yes
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
 
 5. limit client body size
 	- {http,server,location}.client_max_body_size
 	- default: 1m
+	- multiple: no
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
 
 6. setup routes with one or multiple of the following rules/configuration
 (routes won't be using regexp)
+	- location == route in nginx-speak
 	- server.location
 	- default: none
+	- multiple: yes
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#location
 
 6.1 define a list of accepted http methods for the route
 	- location.limit_except
 	- default: none
+	- multiple: no
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except
 
 6.2 define a http redirection
-	- {server,location}.return
+	- location.return
 	- default: none
+	- multiple: yes
 	- https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
 
 6.3 define a directory or a file from where the file should be searched
 	- location.alias
 	- default: none
+	- multiple: no
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#alias
 
 6.4 turn on or off directory listing
 	- {http,server,location}.autoindex
 	- default: off
+	- multiple: no
 	- https://nginx.org/en/docs/http/ngx_http_autoindex_module.html#autoindex
 
 6.5 set a default file to answer if the request is a directory
 	- {http,server,location}.index
 	- default: index.html
+	- multiple: yes
 	- https://nginx.org/en/docs/http/ngx_http_index_module.html#index
 
 6.6 execute CGI based on certain file extension (for example .php)
 	- no NGINX equivalent
-	- {http,server,location}.cgi -> register file extension (1st arg) and optional handler (2nd arg)
-	- {http,server,location}.cgi_bin -> whitelist a directory for CGI-use, absolute or relative to root directive
+	- {http,server,location}.cgi_ext -> register file extension (1st arg) and optional handler (2nd arg)
+	- default: none
+	- multiple: yes
+	- {http,server,location}.cgi_dir -> whitelist a directory for CGI-use, absolute or relative to root directive
+	- default: cgi-bin
+	- multiple: no
 
 6.7 make it work with POST andd GET methods
 	- probably referring to CGI, since a simple static web server doesn't need POST
@@ -68,6 +83,7 @@
 	- no NGINX equivalent
 	- {http,server,location}.upload_dir -> absolute or relative to root directive
 	- default: ""
+	- multiple: no
 	- always passed as UPLOAD_FILE_PATH to CGI
 
 6.8.1 do you wonder what a CGI is
@@ -100,4 +116,5 @@
 7. define a root for various file operations
 	- {http,server,location}.root
 	- default: html
+	- multiple: no
 	- https://nginx.org/en/docs/http/ngx_http_core_module.html#root

--- a/SubjectRequirementsForConfig.txt
+++ b/SubjectRequirementsForConfig.txt
@@ -1,0 +1,103 @@
+# Contexts
+- Main, Events, Http, Server, Location
+
+# Subject
+1. choose port and host for each server
+	- server.listen
+	- default: 0.0.0.0:8000
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#listen
+
+2. setup server_names or not
+	- server.server_name
+	- default: ""
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#server_name
+
+3. the first server for a host:port will be the default for this host:port (that means it will answer to all the requests that don't belong to an other server).
+	- https://nginx.org/en/docs/http/request_processing.html
+
+4. setup default error pages
+	- {http,server,location}.error_page
+	- default: none
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
+
+5. limit client body size
+	- {http,server,location}.client_max_body_size
+	- default: 1m
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+
+6. setup routes with one or multiple of the following rules/configuration
+(routes won't be using regexp)
+	- server.location
+	- default: none
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#location
+
+6.1 define a list of accepted http methods for the route
+	- location.limit_except
+	- default: none
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#limit_except
+
+6.2 define a http redirection
+	- {server,location}.return
+	- default: none
+	- https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
+
+6.3 define a directory or a file from where the file should be searched
+	- location.alias
+	- default: none
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#alias
+
+6.4 turn on or off directory listing
+	- {http,server,location}.autoindex
+	- default: off
+	- https://nginx.org/en/docs/http/ngx_http_autoindex_module.html#autoindex
+
+6.5 set a default file to answer if the request is a directory
+	- {http,server,location}.index
+	- default: index.html
+	- https://nginx.org/en/docs/http/ngx_http_index_module.html#index
+
+6.6 execute CGI based on certain file extension (for example .php)
+	- no NGINX equivalent
+	- {http,server,location}.cgi -> register file extension (1st arg) and optional handler (2nd arg)
+	- {http,server,location}.cgi_bin -> whitelist a directory for CGI-use, absolute or relative to root directive
+
+6.7 make it work with POST andd GET methods
+	- probably referring to CGI, since a simple static web server doesn't need POST
+
+6.8 make the route able to accept uploaded files and configure where they should be saved
+	- no NGINX equivalent
+	- {http,server,location}.upload_dir -> absolute or relative to root directive
+	- default: ""
+	- always passed as UPLOAD_FILE_PATH to CGI
+
+6.8.1 do you wonder what a CGI is
+	- yes
+
+6.8.2 because you won't call the CGI directly, use the full path as PATH_INFO
+	- env["PATH_INFO"] = WHO KNOWS IDK, ubuntu_cgi_tester might give a hint
+	- means: execve("/bin/python3", {"/bin/python3", "/full/path/cgi-bin/test.py", NULL}, env);
+	- but also:
+	- means: execve("/full/path/cgi-bin/test.cgi", {"/full/path/cgi-bin/test.cgi", NULL}, env;
+
+6.8.3 just remember that, for chunked request, your server needs to unchunk it, the CGI will expect EOF as end of the body
+	- refers the `transfer-encoding: chunked` requests
+
+6.8.4 same things for the output of the CGI. If no content_length is returned from the CGI, EOF will mark the end of the returned data
+	- need to collect all stdout from CGI script, then send as response with content-length
+
+6.8.5 your program should call the CGI with the file requested as the first argument
+	- see 6.8.2 and 6.6, it depends on how the cgi extension was registered
+	- the CGI script should definitely not receive additional arguments, that's not how CGI works
+
+6.8.6 the cgi should be run in the correct directory for relative path file access
+	- chdir should be applied before execve
+
+6.8.7 your server should work with one CGI
+	- they mean "at least" one, not exactly one
+	- we'll use python because easier
+
+# not mentioned in subject
+7. define a root for various file operations
+	- {http,server,location}.root
+	- default: html
+	- https://nginx.org/en/docs/http/ngx_http_core_module.html#root

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,22 +1,16 @@
-pid run/webserv.pid;
-
-#worker_processes invalid;
-worker_processes auto;
+root html;
 
 http {
 	server {
-		listen 127.0.0.1:8080;
-		server_name server1;
-
-		access_log log/server1_access.log;
-		error_log log/server1_error.log;
+		listen 0x7f.0.0.1:8080;
+		server_name "server1";
 
 		root html/server1;
 
 		index index.html;
 
 		location / {
-			allowed_methods GET;
+			limit_except GET;
 		}
 	}
 
@@ -24,15 +18,12 @@ http {
 		listen 127.0.0.1:8081;
 		server_name server2;
 
-		access_log log/server2_access.log;
-		error_log log/server2_error.log;
-
 		root html/server2;
 
 		index index.html;
 
 		location / {
-			allowed_methods POST;
+			limit_except POST;
 		}
 	}
 }

--- a/conf/testing.conf
+++ b/conf/testing.conf
@@ -1,24 +1,16 @@
-pid run/webserv.pid;
-
-listen 127.0.0.1 8080;
- 
-#worker_processes hallo;
-worker_processes auto;
+root html;
 
 http {
 	server {
 		listen 127.0.0.1 8080;
 		server_name server1;
 
-		access_log log/server1_access.log;
-		error_log log/server1_error.log;
-
 		root html/server1;
 
 		index index.html;
 
 		location / {
-			allowed_methods GET;
+			limit_except GET;
 		}
 	}
 
@@ -26,16 +18,13 @@ http {
 		listen 127.0.0.1 8081;
 		server_name server2;
 
-		access_log log/server2_access.log;
-		error_log log/server2_error.log;
-
 		root html/server2;
 
 		index index.html;
 
 		location / {
-			allowed_methods GET; #WHATEVER;
-			allowed_methods GET POST; #WHATEVER; # This overwrites the previous directive
+			limit_except GET; #WHATEVER;
+			limit_except GET POST; #WHATEVER; # This overwrites the previous directive atm, not good
 		}
 	}
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -245,7 +245,7 @@ static Tokens lexConfig(string rawConfig) {
 	return tokens;
 }
 
-void updateDefaults(Config& config) {
+static void updateDefaults(Config& config) {
 	populateDefaultMainDirectives(config.first);
 	for (ServerCtxs::iterator server = config.second.begin(); server != config.second.end(); ++server) {
 		populateDefaultServerDirectives(server->first, config.first);
@@ -255,46 +255,13 @@ void updateDefaults(Config& config) {
 	}
 }
 
-void checkDirectives(Config& config) {
+static void checkDirectives(Config& config) {
 	checkMainDirectives(config.first);
 	for (ServerCtxs::iterator server = config.second.begin(); server != config.second.end(); ++server) {
 		checkServerDirectives(server->first);
 		for (LocationCtxs::iterator location = server->second.begin(); location != server->second.end(); ++location) {
 			checkLocationDirectives(location->second);
 		}
-	}
-}
-
-static Arguments processIPv4Address(const Arguments& arguments) {
-	if (arguments.size() >= 2)
-		return arguments;
-	else if (arguments.size() == 1 && arguments[0].empty())
-		return arguments;
-	else if (arguments.size() <= 0)
-		return arguments;
-	string host = arguments[0];
-	string ipAddress;
-	string port;
-	Arguments newArgs;
-	string::size_type pos;
-	if ((pos = host.rfind(':')) != string::npos) {
-		ipAddress = host.substr(0, pos);
-		port = host.substr(pos + 1);
-	} else if ((pos = host.find('.')) != string::npos) {
-		ipAddress = host;
-		port = Constants::defaultPort;
-	} else {
-		ipAddress = Constants::defaultAddress;
-		port = host;
-	}
-	newArgs.push_back(ipAddress);
-	newArgs.push_back(port);
-	return newArgs;
-}
-
-void postProcess(Config& config) {
-	for (ServerCtxs::iterator server = config.second.begin(); server != config.second.end(); ++server) {
-		server->first["listen"] = processIPv4Address(server->first["listen"]);
 	}
 }
 
@@ -311,8 +278,6 @@ Config parseConfig(string rawConfig) {
 	Config config = std::make_pair(directives, httpBlock);
 
 	updateDefaults(config);
-
-	postProcess(config);
 
 	checkDirectives(config);
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -277,7 +277,7 @@ static Arguments processIPv4Address(const Arguments& arguments) {
 	string port;
 	Arguments newArgs;
 	string::size_type pos;
-	if ((pos = host.find(':')) != string::npos) {
+	if ((pos = host.rfind(':')) != string::npos) {
 		ipAddress = host.substr(0, pos);
 		port = host.substr(pos + 1);
 	} else if ((pos = host.find('.')) != string::npos) {

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -293,7 +293,6 @@ static Arguments processIPv4Address(const Arguments& arguments) {
 }
 
 void postProcess(Config& config) {
-	config.first["listen"] = processIPv4Address(config.first["listen"]);
 	for (ServerCtxs::iterator server = config.second.begin(); server != config.second.end(); ++server) {
 		server->first["listen"] = processIPv4Address(server->first["listen"]);
 	}

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -24,41 +24,41 @@ static void updateIfNotExistsVec(Directives& directives, const string& directive
 		directives[directive] = value;
 }
 
-static void populateDefaultGlobalDirectives(Directives& directives) {
-	updateIfNotExists(directives, "pid", "run/webserv.pid");
-	updateIfNotExists(directives, "worker_processes", "auto");
-
-	updateIfNotExists(directives, "index", "index.html");
-	updateIfNotExists(directives, "root", "html");
-	updateIfNotExists(directives, "listen", "127.0.0.1:80");
-	updateIfNotExists(directives, "access_log", "log/access.log");
-	updateIfNotExists(directives, "error_log", "log/error.log");
-}
-
-static void takeFromDefault(Directives& directives, Directives& globalDirectives, const string& directive, const string& value) {
-	if (globalDirectives.find(directive) == globalDirectives.end())
+static void takeFromDefault(Directives& directives, Directives& mainDirectives, const string& directive, const string& value) {
+	if (mainDirectives.find(directive) == mainDirectives.end())
 		updateIfNotExists(directives, directive, value);
 	else
-		updateIfNotExistsVec(directives, directive, globalDirectives[directive]);
+		updateIfNotExistsVec(directives, directive, mainDirectives[directive]);
 }
 
-static void populateDefaultServerDirectives(Directives& directives, Directives& globalDirectives) {
-	takeFromDefault(directives, globalDirectives, "index", "index.html");
-	takeFromDefault(directives, globalDirectives, "root", "html");
-	takeFromDefault(directives, globalDirectives, "listen", "127.0.0.1:80");
-	takeFromDefault(directives, globalDirectives, "access_log", "log/access.log");
-	takeFromDefault(directives, globalDirectives, "error_log", "log/error.log");
+static void populateDefaultMainDirectives(Directives& directives) {
+	updateIfNotExists(directives, "autoindex", "off");
+	updateIfNotExists(directives, "cgi_dir", "cgi-bin");
+	updateIfNotExists(directives, "client_max_body_size", "1m");
+	updateIfNotExists(directives, "index", "index.html");
+	updateIfNotExists(directives, "root", "html");
+	updateIfNotExists(directives, "upload_dir", "");
+}
 
+static void populateDefaultServerDirectives(Directives& directives, Directives& mainDirectives) {
+	takeFromDefault(directives, mainDirectives, "autoindex", "off");
+	takeFromDefault(directives, mainDirectives, "cgi_dir", "cgi-bin");
+	takeFromDefault(directives, mainDirectives, "client_max_body_size", "1m");
+	takeFromDefault(directives, mainDirectives, "index", "index.html");
+	takeFromDefault(directives, mainDirectives, "root", "html");
+	takeFromDefault(directives, mainDirectives, "upload_dir", "");
+
+	updateIfNotExists(directives, "listen", "*:8000");
 	updateIfNotExists(directives, "server_name", "");
 }
 
-static void populateDefaultRouteDirectives(Directives& directives, Directives& serverDirectives) {
+static void populateDefaultLocationDirectives(Directives& directives, Directives& serverDirectives) {
+	takeFromDefault(directives, serverDirectives, "autoindex", "off");
+	takeFromDefault(directives, serverDirectives, "cgi_dir", "cgi-bin");
+	takeFromDefault(directives, serverDirectives, "client_max_body_size", "1m");
 	takeFromDefault(directives, serverDirectives, "index", "index.html");
 	takeFromDefault(directives, serverDirectives, "root", "html");
-
-	updateIfNotExists(directives, "allowed_methods", "GET");
-	// updateIfNotExists(directives, "alias", "GET"); // has no default
-	// updateIfNotExistsVec(directives, "return", VEC(string, "", "")); // has no default
+	takeFromDefault(directives, serverDirectives, "upload_dir", "");
 }
 
 static Arguments parseArguments(Tokens& tokens) {
@@ -102,8 +102,8 @@ static Directives parseDirectives(Tokens& tokens) {
 	return directives;
 }
 
-static RouteCtx parseRoute(Tokens& tokens) {
-	RouteCtx route;
+static LocationCtx parseLocation(Tokens& tokens) {
+	LocationCtx location;
 
 	if (tokens.empty() || tokens.front().second != "location")
 		throw runtime_error(Errors::Config::ParseError(tokens));
@@ -112,31 +112,31 @@ static RouteCtx parseRoute(Tokens& tokens) {
 	if (tokens.empty() || tokens.front().first != TOK_WORD)
 		throw runtime_error(Errors::Config::ParseError(tokens));
 
-	route.first = tokens.front().second;
+	location.first = tokens.front().second;
 	tokens.pop_front();
 
 	if (tokens.empty() || tokens.front().first != TOK_OPENING_BRACE)
 		throw runtime_error(Errors::Config::ParseError(tokens));
 	tokens.pop_front();
 
-	route.second = parseDirectives(tokens);
+	location.second = parseDirectives(tokens);
 
 	if (tokens.empty() || tokens.front().first != TOK_CLOSING_BRACE)
 		throw runtime_error(Errors::Config::ParseError(tokens));
 	tokens.pop_front();
 
-	return route;
+	return location;
 }
 
-static RouteCtxs parseRoutes(Tokens& tokens) {
-	std::vector<RouteCtx> routes;
+static LocationCtxs parseLocations(Tokens& tokens) {
+	std::vector<LocationCtx> locations;
 	while (true) {
 		if (tokens.empty() || tokens.front().second != "location")
 			break;
-		RouteCtx route = parseRoute(tokens);
-		routes.push_back(route);
+		LocationCtx location = parseLocation(tokens);
+		locations.push_back(location);
 	}
-	return routes;
+	return locations;
 }
 
 static ServerCtx parseServer(Tokens& tokens) {
@@ -150,8 +150,8 @@ static ServerCtx parseServer(Tokens& tokens) {
 	tokens.pop_front();
 
 	Directives directives = parseDirectives(tokens);
-	RouteCtxs routes = parseRoutes(tokens);
-	server = std::make_pair(directives, routes);
+	LocationCtxs locations = parseLocations(tokens);
+	server = std::make_pair(directives, locations);
 
 	if (tokens.empty() || tokens.front().first != TOK_CLOSING_BRACE)
 		throw runtime_error(Errors::Config::ParseError(tokens));
@@ -246,21 +246,21 @@ static Tokens lexConfig(string rawConfig) {
 }
 
 void updateDefaults(Config& config) {
-	populateDefaultGlobalDirectives(config.first);
+	populateDefaultMainDirectives(config.first);
 	for (ServerCtxs::iterator server = config.second.begin(); server != config.second.end(); ++server) {
 		populateDefaultServerDirectives(server->first, config.first);
-		for (RouteCtxs::iterator route = server->second.begin(); route != server->second.end(); ++route) {
-			populateDefaultRouteDirectives(route->second, server->first);
+		for (LocationCtxs::iterator location = server->second.begin(); location != server->second.end(); ++location) {
+			populateDefaultLocationDirectives(location->second, server->first);
 		}
 	}
 }
 
 void checkDirectives(Config& config) {
-	checkGlobalDirectives(config.first);
+	checkMainDirectives(config.first);
 	for (ServerCtxs::iterator server = config.second.begin(); server != config.second.end(); ++server) {
 		checkServerDirectives(server->first);
-		for (RouteCtxs::iterator route = server->second.begin(); route != server->second.end(); ++route) {
-			checkRouteDirectives(route->second);
+		for (LocationCtxs::iterator location = server->second.begin(); location != server->second.end(); ++location) {
+			checkLocationDirectives(location->second);
 		}
 	}
 }
@@ -323,24 +323,24 @@ Config parseConfig(string rawConfig) {
 	return config;
 }
 /* How to access Config config:
-# Global directives:
+# Main directives:
 config.first["pid"] -> gives back vector of args
 config.first["pid"][0] -> most directives have only one argument, so you'll use this pattern quite often
                           watch out that some directive _might_ have zero arguments, although I can't think of any, but the parser allows that
 
 # ServerCtxs configs
 config.second -> vector of ServerCtx
-config.second[0] -> pair of directives and routes
+config.second[0] -> pair of directives and locations
 config.second[0].first -> directives specific for a server (order is not important, which is why Directives is a map)
 config.second[0].first["server_name"] -> how you would access the server name for a given server
 
-## Routes
-config.second[0].second -> vector of routes for a server (order is important for the routers (top-bottom)!, that's why it's a vector)
-config.second[0].second[0] -> first route (if there are any, check for empty!)
-config.second[0].second[0].first -> the actual route (a string), something like /web
+## Locations
+config.second[0].second -> vector of locations for a server (order is important for the locations (top-bottom)!, that's why it's a vector)
+config.second[0].second[0] -> first location (if there are any, check for empty!)
+config.second[0].second[0].first -> the actual location (a string), something like /web
 config.second[0].second[0].second -> again, Directives, so a map of directives similar to above
-config.second[0].second[0].second["allowed_methods"] -> which methods does this route support? mutliple arguments!
-config.second[0].second[0].second["allowed_methods"][0] == "GET" -> check if the first allowed method for this route is "GET"
+config.second[0].second[0].second["limit_except"] -> which methods does this location support? mutliple arguments!
+config.second[0].second[0].second["limit_except"][0] == "GET" -> check if the first allowed method for this location is "GET"
 
 
 # Example JSON (might want to add more keys, instead of just plain lists, but let's keep it MVP)
@@ -363,7 +363,7 @@ config.second[0].second[0].second["allowed_methods"][0] == "GET" -> check if the
       [ [ "/",
           {
             "index": [ "index.html" ],
-            "allowed_methods": [ "GET" ],
+            "limit_except": [ "GET" ],
             "return": [ "" ],
             "root": [ "html/server1" ]
           }
@@ -382,7 +382,7 @@ config.second[0].second[0].second["allowed_methods"][0] == "GET" -> check if the
           "/",
           {
             "index": [ "index.html" ],
-            "allowed_methods": [ "GET" ],
+            "limit_except": [ "GET" ],
             "return": [ "" ],
             "root": [ "html/server2" ],
             "try_files": [ "$uri", "$uri/", "=404" ]

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -9,9 +9,9 @@
 typedef std::vector<std::string> Arguments;
 typedef std::pair<std::string, Arguments> Directive;
 typedef std::map<std::string, Arguments> Directives;
-typedef std::pair<std::string, Directives> RouteCtx;
-typedef std::vector<RouteCtx> RouteCtxs;
-typedef std::pair<Directives, RouteCtxs> ServerCtx;
+typedef std::pair<std::string, Directives> LocationCtx;
+typedef std::vector<LocationCtx> LocationCtxs;
+typedef std::pair<Directives, LocationCtxs> ServerCtx;
 typedef std::vector<ServerCtx> ServerCtxs;
 typedef std::pair<Directives, ServerCtxs> Config;
 

--- a/src/DirectiveValidation.cpp
+++ b/src/DirectiveValidation.cpp
@@ -149,11 +149,33 @@ static inline bool checkRoot(const string& ctx, const string& directive, const A
 	return false;
 }
 
+static inline Arguments processIPv4Address(const string& host) {
+	string ipAddress;
+	string port;
+	Arguments newArgs;
+	string::size_type pos;
+	if ((pos = host.rfind(':')) != string::npos) {
+		ipAddress = host.substr(0, pos);
+		port = host.substr(pos + 1);
+	} else if ((pos = host.find('.')) != string::npos) {
+		ipAddress = host;
+		port = Constants::defaultPort;
+	} else {
+		ipAddress = Constants::defaultAddress;
+		port = host;
+	}
+	newArgs.push_back(ipAddress);
+	newArgs.push_back(port);
+	return newArgs;
+}
+
 static inline bool checkListen(const string& ctx, const string& directive, Arguments& arguments) {
 	if (directive == "listen") {
-		ensureArity(ctx, directive, arguments, 2, 2);
-		ensureValidHost(ctx, directive, arguments[0]);
-		ensureValidPort(ctx, directive, arguments[1]);
+		ensureArity(ctx, directive, arguments, 1, 1);
+		Arguments ipAndPort = processIPv4Address(arguments[0]);
+		ensureValidHost(ctx, directive, ipAndPort[0]);
+		ensureValidPort(ctx, directive, ipAndPort[1]);
+		arguments = ipAndPort;
 		return true;
 	}
 	return false;

--- a/src/DirectiveValidation.cpp
+++ b/src/DirectiveValidation.cpp
@@ -70,7 +70,7 @@ static inline void ensureValidSize(const string& ctx, const string& directive, c
 	while (c != argument.end() && std::isdigit(*c)) ++c;
 	if (c == argument.end())
 		return;
-	if (std::strchr("KMGT", std::toupper(*c)) && c + 1 == argument.end())
+	if (std::strchr("kmgt", std::tolower(*c)) && c + 1 == argument.end())
 		return;
 	throw runtime_error(Errors::Config::DirectiveInvalidSizeArgument(ctx, directive, argument));
 }
@@ -101,12 +101,13 @@ static inline void ensureStatusCode(const string& ctx, const string& directive, 
 	throw runtime_error(Errors::Config::DirectiveInvalidStatusCodeArgument(ctx, directive, argument));
 }
 
-static inline void ensureValidHost(const string& directive, const string& argument) {
-	if (argument == "*")
+static inline void ensureValidHost(const string& ctx, const string& directive, string& argument) {
+	if (argument == "*") {
+		argument = "0.0.0.0";
 		return;
 	}
 	char buf[16];
-	if (inet_pton(AF_INET, argument.c_str(), &buf) == 1)
+	if (inet_aton(argument.c_str(), NULL) == 1)
 		return;
 	if (inet_pton(AF_INET6, argument.c_str(), &buf) == 1)
 		throw runtime_error(Errors::Config::DirectiveIPv6NotSupported(ctx, directive));

--- a/src/DirectiveValidation.hpp
+++ b/src/DirectiveValidation.hpp
@@ -2,6 +2,6 @@
 
 #include "Config.hpp"
 
-void checkGlobalDirectives(const Directives& directives);
-void checkServerDirectives(const Directives& directives);
-void checkRouteDirectives(const Directives& directives);
+void checkMainDirectives(Directives& directives);
+void checkServerDirectives(Directives& directives);
+void checkLocationDirectives(Directives& directives);

--- a/src/Errors.cpp
+++ b/src/Errors.cpp
@@ -52,7 +52,7 @@ const string Errors::Config::DirectiveArgumentPortNumberTooLow(const string& ctx
 }
 
 const string Errors::Config::DirectiveIPv6NotSupported(const string& ctx, const string& directive) {
-	return CONFIG_ERROR_PREFIX(ctx) + cmt("IP address argument for directive ") + repr(directive) + cmt(" must not be IPv6");
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("IP address for directive ") + repr(directive) + cmt(" must not be IPv6");
 }
 
 const string Errors::Config::DirectiveInvalidBooleanArgument(const string& ctx, const string& directive, const string& argument) {
@@ -60,7 +60,7 @@ const string Errors::Config::DirectiveInvalidBooleanArgument(const string& ctx, 
 }
 
 const string Errors::Config::DirectiveInvalidIpAddressArgument(const string& ctx, const string& directive, const string& argument) {
-	return CONFIG_ERROR_PREFIX(ctx) + cmt("IP address argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("IP address ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
 }
 
 const string Errors::Config::DirectiveInvalidSizeArgument(const string& ctx, const string& directive, const string& argument) {
@@ -76,7 +76,7 @@ const string Errors::Config::InvalidDirectiveArgument(const string& ctx, const s
 }
 
 const string Errors::Config::InvalidDirectiveArgumentCount(const string& ctx, const string& directive, unsigned int count, int min, int max) {
-	return CONFIG_ERROR_PREFIX(ctx) + cmt("Argument count of ") + repr(count) + cmt(" for directive ") + repr(directive) + cmt(" is invalid. Must be at least ") + repr(min) + (max == -1 ? "" : cmt(" and at most ") + repr(max));
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Argument count of ") + repr(count) + cmt(" for directive ") + repr(directive) + cmt(" is invalid.") + (min == max ? cmt(" Must be exactly ") + repr(min) : cmt(" Must be at least ") + repr(min) + (max == -1 ? "" : cmt(" and at most ") + repr(max)));
 }
 
 const string Errors::Config::UnknownDirective(const string& ctx, const string& directive) {

--- a/src/Errors.cpp
+++ b/src/Errors.cpp
@@ -3,7 +3,8 @@
 #include "Errors.hpp"
 #include "Repr.hpp"
 
-#include <sstream>
+#define CONFIG_ERROR_PREFIX(ctx) \
+	cmt("Config error: ") + cmt("In context ") + repr(ctx) + cmt(": ")
 
 using std::string;
 
@@ -21,71 +22,71 @@ const string Errors::Config::ParseError(Tokens& tokens) {
 	return cmt("Failed to parse configuration file: Unexpected token: '") + punct(tokens.front().second) + cmt("'");
 }
 
-const string Errors::Config::DirectiveArgumentEmpty(const string& directive) {
-	return cmt("Argument for directive ") + repr(directive) + cmt(" must not be empty");
+const string Errors::Config::DirectiveArgumentEmpty(const string& ctx, const string& directive) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Argument for directive ") + repr(directive) + cmt(" must not be empty");
 }
 
-const string Errors::Config::DirectiveArgumentInvalidPort(const string& directive, const string& argument) {
-	return cmt("Port argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+const string Errors::Config::DirectiveArgumentInvalidPort(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Port argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
 }
 
-const string Errors::Config::DirectiveArgumentNotNumeric(const string& directive, const string& argument) {
-	return cmt("Number argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is not numeric");
+const string Errors::Config::DirectiveArgumentNotNumeric(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Number argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is not numeric");
 }
 
-const string Errors::Config::DirectiveArgumentNotUnique(const string& directive, const string& argument) {
-	return cmt("Argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is not unique");
+const string Errors::Config::DirectiveArgumentNotUnique(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is not unique");
 }
 
 // Note: This case actually cannot happen, because Directives is a map so keys are always unique already
-const string Errors::Config::DirectiveNotUnique(const string& directive) {
-	return cmt("Directive ") + repr(directive) + cmt(" is not unique");
+const string Errors::Config::DirectiveNotUnique(const string& ctx, const string& directive) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Directive ") + repr(directive) + cmt(" is not unique");
 }
 
-const string Errors::Config::DirectiveArgumentPortNumberTooHigh(const string& directive, const string& argument) {
-	return cmt("Port argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is too high");
+const string Errors::Config::DirectiveArgumentPortNumberTooHigh(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Port argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is too high");
 }
 
-const string Errors::Config::DirectiveArgumentPortNumberTooLow(const string& directive, const string& argument) {
-	return cmt("Port argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is too low");
+const string Errors::Config::DirectiveArgumentPortNumberTooLow(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Port argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is too low");
 }
 
-const string Errors::Config::DirectiveIPv6NotSupported(const string& directive) {
-	return cmt("IP address argument for directive ") + repr(directive) + cmt(" must not be IPv6");
+const string Errors::Config::DirectiveIPv6NotSupported(const string& ctx, const string& directive) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("IP address argument for directive ") + repr(directive) + cmt(" must not be IPv6");
 }
 
-const string Errors::Config::DirectiveInvalidBooleanArgument(const string& directive, const string& argument) {
-	return cmt("Bool argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+const string Errors::Config::DirectiveInvalidBooleanArgument(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Bool argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
 }
 
-const string Errors::Config::DirectiveInvalidIpAddressArgument(const string& directive, const string& argument) {
-	return cmt("IP address argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+const string Errors::Config::DirectiveInvalidIpAddressArgument(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("IP address argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
 }
 
-const string Errors::Config::DirectiveInvalidSizeArgument(const string& directive, const string& argument) {
-	return cmt("Size argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+const string Errors::Config::DirectiveInvalidSizeArgument(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Size argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
 }
 
-const string Errors::Config::DirectiveInvalidStatusCodeArgument(const string& directive, const string& argument) {
-	return cmt("Status code argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+const string Errors::Config::DirectiveInvalidStatusCodeArgument(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Status code argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
 }
 
-const string Errors::Config::InvalidDirectiveArgument(const string& directive, const string& argument, const Arguments& options) {
-	return cmt("Argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid. Must be one of ") + repr(options);
+const string Errors::Config::InvalidDirectiveArgument(const string& ctx, const string& directive, const string& argument, const Arguments& options) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid. Must be one of ") + repr(options);
 }
 
-const string Errors::Config::InvalidDirectiveArgumentCount(const string& directive, unsigned int count, unsigned int min, unsigned int max) {
-	return cmt("Argument count of ") + repr(count) + cmt(" for directive ") + repr(directive) + cmt(" is invalid. Must be at least ") + repr(min) + cmt(" and at most ") + repr(max);
+const string Errors::Config::InvalidDirectiveArgumentCount(const string& ctx, const string& directive, unsigned int count, int min, int max) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Argument count of ") + repr(count) + cmt(" for directive ") + repr(directive) + cmt(" is invalid. Must be at least ") + repr(min) + (max == -1 ? "" : cmt(" and at most ") + repr(max));
 }
 
-const string Errors::Config::UnknownDirective(const string& directive) {
-	return cmt("Unknown directive: ") + repr(directive);
+const string Errors::Config::UnknownDirective(const string& ctx, const string& directive) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("Unknown directive: ") + repr(directive);
 }
 
 const string Errors::Config::ZeroServers() {
-	return cmt("There must be at least one server in the config");
+	return CONFIG_ERROR_PREFIX((char*)"http") + cmt("There must be at least one ") + repr((char*)"server") + cmt(" directive");
 }
 
 const string Errors::Config::EmptyConfig() {
-	return cmt("The config file is empty");
+	return CONFIG_ERROR_PREFIX((char*)"main") + cmt("The ") + repr((char*)"http") + cmt(" context is missing");
 }

--- a/src/Errors.hpp
+++ b/src/Errors.hpp
@@ -12,21 +12,21 @@ namespace Errors {
 	namespace Config {
 		const string OpeningError(const string& path);
 		const string ParseError(Tokens& tokens);
-		const string DirectiveArgumentEmpty(const string& directive);
-		const string DirectiveArgumentInvalidPort(const string& directive, const string& argument);
-		const string DirectiveArgumentNotNumeric(const string& directive, const string& argument);
-		const string DirectiveArgumentNotUnique(const string& directive, const string& argument);
-		const string DirectiveNotUnique(const string& directive);
-		const string DirectiveArgumentPortNumberTooHigh(const string& directive, const string& argument);
-		const string DirectiveArgumentPortNumberTooLow(const string& directive, const string& argument);
-		const string DirectiveIPv6NotSupported(const string& directive);
-		const string DirectiveInvalidBooleanArgument(const string& directive, const string& argument);
-		const string DirectiveInvalidIpAddressArgument(const string& directive, const string& argument);
-		const string DirectiveInvalidSizeArgument(const string& directive, const string& argument);
-		const string DirectiveInvalidStatusCodeArgument(const string& directive, const string& argument);
-		const string InvalidDirectiveArgument(const string& directive, const string& argument, const Arguments& options);
-		const string InvalidDirectiveArgumentCount(const string& directive, unsigned int count, unsigned int min, unsigned int max);
-		const string UnknownDirective(const string& directive);
+		const string DirectiveArgumentEmpty(const string& ctx, const string& directive);
+		const string DirectiveArgumentInvalidPort(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveArgumentNotNumeric(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveArgumentNotUnique(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveNotUnique(const string& ctx, const string& directive);
+		const string DirectiveArgumentPortNumberTooHigh(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveArgumentPortNumberTooLow(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveIPv6NotSupported(const string& ctx, const string& directive);
+		const string DirectiveInvalidBooleanArgument(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveInvalidIpAddressArgument(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveInvalidSizeArgument(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveInvalidStatusCodeArgument(const string& ctx, const string& directive, const string& argument);
+		const string InvalidDirectiveArgument(const string& ctx, const string& directive, const string& argument, const Arguments& options);
+		const string InvalidDirectiveArgumentCount(const string& ctx, const string& directive, unsigned int count, int min, int max);
+		const string UnknownDirective(const string& ctx, const string& directive);
 		const string ZeroServers();
 		const string EmptyConfig();
 	}

--- a/src/Repr.hpp
+++ b/src/Repr.hpp
@@ -130,7 +130,7 @@ template <> struct ReprWrapper<bool> {
 	}
 };
 
-// not escaping string value atm
+// TODO: @timo: escape for string literal
 template <>
 struct ReprWrapper<string> {
 	static inline string
@@ -142,7 +142,7 @@ struct ReprWrapper<string> {
 	}
 };
 
-// not escaping string value atm
+// TODO: @timo: escape for string literal
 template <> 
 struct ReprWrapper<char*> {
 	static inline string
@@ -154,7 +154,7 @@ struct ReprWrapper<char*> {
 	}
 };
 
-// not escaping char value atm
+// TODO: @timo: escape for char literal
 #define CHAR_REPR(T) template <> \
 	struct ReprWrapper<T> { \
 		static inline string \


### PR DESCRIPTION
This PR is 9 commits (fast-forward) ahead of #3, so #3 should be merged first.
# Main features
- Add validation and documentation for ALL required (as per subject) directives.
- Improve error throwing messages
- Fix parsing of the host:port argument for the listen directive

# Not in this PR yet
- semantics of some directives are still wrong, i.e. the `listen` directive should be able to be specified multiple times
- also the `error_page`, `server_name`, and some other directives are "multi" directives.
- this is fixed in a later commit/PR, but will require the transition from map to multimap