### PR TITLE
Flatten http context

### DIFF
--- a/SubjectRequirementsForConfig.txt
+++ b/SubjectRequirementsForConfig.txt
@@ -1,5 +1,5 @@
 # Contexts
-- Main, Events, Http, Server, Location
+- Http, Server, Location
 
 # Subject
 1. choose port and host for each server

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,29 +1,27 @@
 root html;
 
-http {
-	server {
-		listen 0x7f.0.0.1:8080;
-		server_name "server1";
+server {
+	listen 0x7f.0.0.1:8080;
+	server_name "server1";
 
-		root html/server1;
+	root html/server1;
 
-		index index.html;
+	index index.html;
 
-		location / {
-			limit_except GET;
-		}
+	location / {
+		limit_except GET;
 	}
+}
 
-	server {
-		listen 127.0.0.1:8081;
-		server_name server2;
+server {
+	listen 127.0.0.1:8081;
+	server_name server2;
 
-		root html/server2;
+	root html/server2;
 
-		index index.html;
+	index index.html;
 
-		location / {
-			limit_except POST;
-		}
+	location / {
+		limit_except POST;
 	}
 }

--- a/conf/testing.conf
+++ b/conf/testing.conf
@@ -1,30 +1,28 @@
 root html;
 
-http {
-	server {
-		listen 127.0.0.1 8080;
-		server_name server1;
+server {
+	listen 127.0.0.1 8080;
+	server_name server1;
 
-		root html/server1;
+	root html/server1;
 
-		index index.html;
+	index index.html;
 
-		location / {
-			limit_except GET;
-		}
+	location / {
+		limit_except GET;
 	}
+}
 
-	server {
-		listen 127.0.0.1 8081;
-		server_name server2;
+server {
+	listen 127.0.0.1 8081;
+	server_name server2;
 
-		root html/server2;
+	root html/server2;
 
-		index index.html;
+	index index.html;
 
-		location / {
-			limit_except GET; #WHATEVER;
-			limit_except GET POST; #WHATEVER; # This overwrites the previous directive atm, not good
-		}
+	location / {
+		limit_except GET; #WHATEVER;
+		limit_except GET POST; #WHATEVER; # This overwrites the previous directive atm, not good
 	}
 }

--- a/src/DirectiveValidation.cpp
+++ b/src/DirectiveValidation.cpp
@@ -17,8 +17,8 @@
 #include "Constants.hpp"
 #include "Utils.hpp"
 
-#define CHECKFN_MAIN(checkFunction) \
-	if (checkFunction("main", directive, arguments) && ++counts[directive] <= 1) \
+#define CHECKFN_HTTP(checkFunction) \
+	if (checkFunction("http", directive, arguments) && ++counts[directive] <= 1) \
 		continue
 
 #define CHECKFN_SERVER(checkFunction) \
@@ -278,23 +278,23 @@ static inline bool checkUploadDir(const string& ctx, const string& directive, co
 	return false;
 }
 
-void checkMainDirectives(Directives& directives) {
+void checkHttpDirectives(Directives& directives) {
 	map<string, unsigned int> counts;
 	for (Directives::iterator kv = directives.begin(); kv != directives.end(); ++kv) {
 		const string& directive = kv->first;
 		Arguments& arguments = kv->second;
-		CHECKFN_MAIN(checkAutoindex);
-		CHECKFN_MAIN(checkCgiDir);
-		CHECKFN_MAIN(checkCgiExt);
-		CHECKFN_MAIN(checkClientMaxBodySize);
-		CHECKFN_MAIN(checkErrorPage);
-		CHECKFN_MAIN(checkIndex);
-		CHECKFN_MAIN(checkRoot);
-		CHECKFN_MAIN(checkRoot);
-		CHECKFN_MAIN(checkUploadDir);
+		CHECKFN_HTTP(checkAutoindex);
+		CHECKFN_HTTP(checkCgiDir);
+		CHECKFN_HTTP(checkCgiExt);
+		CHECKFN_HTTP(checkClientMaxBodySize);
+		CHECKFN_HTTP(checkErrorPage);
+		CHECKFN_HTTP(checkIndex);
+		CHECKFN_HTTP(checkRoot);
+		CHECKFN_HTTP(checkRoot);
+		CHECKFN_HTTP(checkUploadDir);
 		if (counts[directive] > 1)
-			throw runtime_error(Errors::Config::DirectiveNotUnique("main", directive));
-		throw runtime_error(Errors::Config::UnknownDirective("main", directive));
+			throw runtime_error(Errors::Config::DirectiveNotUnique("http", directive));
+		throw runtime_error(Errors::Config::UnknownDirective("http", directive));
 	}
 }
 

--- a/src/DirectiveValidation.hpp
+++ b/src/DirectiveValidation.hpp
@@ -2,6 +2,6 @@
 
 #include "Config.hpp"
 
-void checkMainDirectives(Directives& directives);
+void checkHttpDirectives(Directives& directives);
 void checkServerDirectives(Directives& directives);
 void checkLocationDirectives(Directives& directives);

--- a/src/Errors.cpp
+++ b/src/Errors.cpp
@@ -86,7 +86,3 @@ const string Errors::Config::UnknownDirective(const string& ctx, const string& d
 const string Errors::Config::ZeroServers() {
 	return CONFIG_ERROR_PREFIX((char*)"http") + cmt("There must be at least one ") + repr((char*)"server") + cmt(" directive");
 }
-
-const string Errors::Config::EmptyConfig() {
-	return CONFIG_ERROR_PREFIX((char*)"main") + cmt("The ") + repr((char*)"http") + cmt(" context is missing");
-}


### PR DESCRIPTION
This PR is 2 commits (fast-forward) ahead of #5, so #5 should be merged first.
# Main change (basically):
- change parsing and everything to facilitate the following change:
```nginx
root html;
http {
 server {
  listen 80;
 }
 server {
  listen *:81;
 }
}
```
now is flattened to:
```nginx
root html;

server {
 listen 80;
}
server {
 listen *:81;
}
```
- also rename some stuff