### PR TITLE
Multimap for directives

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -34,7 +34,7 @@ bool directiveExists(const Directives& directives, const string& directive) {
 const Arguments& getFirstDirective(const Directives& directives, const string& directive) {
 	Directives::const_iterator result_itr = directives.find(directive);
 	if (result_itr == directives.end())
-		throw runtime_error("Directives: Multimap Error: Tried to look up non-existing key '" + directive + "'");
+		throw runtime_error(Errors::MultimapIndex(directive));
 	return result_itr->second;
 }
 

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -8,7 +8,7 @@
 
 typedef std::vector<std::string> Arguments;
 typedef std::pair<std::string, Arguments> Directive;
-typedef std::map<std::string, Arguments> Directives;
+typedef std::multimap<std::string, Arguments> Directives;
 typedef std::pair<std::string, Directives> LocationCtx;
 typedef std::vector<LocationCtx> LocationCtxs;
 typedef std::pair<Directives, LocationCtxs> ServerCtx;
@@ -30,3 +30,7 @@ typedef std::deque<Token> Tokens;
 
 std::string readConfig(std::string configPath);
 Config parseConfig(std::string rawConfig);
+
+bool directiveExists(const Directives& directives, const std::string& directive);
+const Arguments& getFirstDirective(const Directives& directives, const std::string& directive);
+std::vector<Arguments> getAllDirectives(const Directives& directives, const std::string& directive);

--- a/src/Errors.cpp
+++ b/src/Errors.cpp
@@ -12,6 +12,10 @@ const string Errors::WrongArgs(int ac) {
 	return cmt("Server started with invalid number of arguments: ") + repr(ac);
 }
 
+const string Errors::MultimapIndex(const string& key) {
+	return cmt("Directives: Multimap Error: Tried to look up non-existing key ") + repr(key);
+}
+
 const string Errors::Config::OpeningError(const string& path) {
 	return cmt("Failed to open configuration file: ") + repr(path);
 }

--- a/src/Errors.hpp
+++ b/src/Errors.hpp
@@ -8,6 +8,7 @@ using std::string;
 
 namespace Errors {
 	const string WrongArgs(int ac);
+	const string MultimapIndex(const string& key);
 
 	namespace Config {
 		const string OpeningError(const string& path);
@@ -28,7 +29,6 @@ namespace Errors {
 		const string InvalidDirectiveArgumentCount(const string& ctx, const string& directive, unsigned int count, int min, int max);
 		const string UnknownDirective(const string& ctx, const string& directive);
 		const string ZeroServers();
-		const string EmptyConfig();
 	}
 }
 

--- a/src/Repr.hpp
+++ b/src/Repr.hpp
@@ -24,6 +24,7 @@
 using std::string;
 using std::vector;
 using std::map;
+using std::multimap;
 using std::pair;
 using ansi::rgb;
 using ansi::rgbBg;
@@ -293,6 +294,44 @@ struct ReprWrapper<map<K, V> > {
 	}
 };
 
+// for multimap
+template <typename K, typename V>
+struct ReprWrapper<multimap<K, V> > {
+	static inline string
+	repr(const multimap<K, V>& m, bool json = false) {
+		std::ostringstream oss;
+		if (json)
+			oss << "{";
+		else if (Constants::verboseLogs)
+			oss << kwrd("std") + punct("::") + kwrd("multimap") + punct("({");
+		else
+			oss << punct("{");
+		int i = 0;
+		for (typename multimap<K, V>::const_iterator it = m.begin(); it != m.end(); ++it) {
+			if (i != 0) {
+				if (json)
+					oss << ", ";
+				else
+					oss << punct(", ");
+			}
+			oss << ReprWrapper<K>::repr(it->first, json);
+			if (json)
+				oss << ": ";
+			else
+				oss << punct(": ");
+			oss << ReprWrapper<V>::repr(it->second, json);
+			++i;
+		}
+		if (json)
+			oss << "}";
+		else if (Constants::verboseLogs)
+			oss << punct("})");
+		else
+			oss << punct("}");
+		return oss.str();
+	}
+};
+
 // for pair
 template <typename F, typename S>
 struct ReprWrapper<pair<F, S> > {
@@ -320,6 +359,9 @@ static inline std::ostream& operator<<(std::ostream& os, const vector<T>& val) {
 
 template<typename K, typename V>
 static inline std::ostream& operator<<(std::ostream& os, const map<K, V>& val) { return os << repr(val, Constants::jsonTrace); }
+
+template<typename K, typename V>
+static inline std::ostream& operator<<(std::ostream& os, const multimap<K, V>& val) { return os << repr(val, Constants::jsonTrace); }
 
 template<typename F, typename S>
 static inline std::ostream& operator<<(std::ostream& os, const pair<F, S>& val) { return os << repr(val, Constants::jsonTrace); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,8 @@
 #include "Logger.hpp"
 #include "Utils.hpp"
 
+#include "Config.hpp"
+
 using std::cout;
 
 int main(int ac, char **av) {


### PR DESCRIPTION
This PR is 2 commits (fast-forward) ahead of #6, so #6 should be merged first.
# Main feature
- Directives are now a multimap, instead of a map. This has significant consequences.
- For example, the following would lead to a compile time error:
```c++
config.second[0].first["listen"]; // get the listen directive from the first server, gives empty vector if "listen" is not in the map
```
- Instead, the following has to be done instead
```c++
#include "Config.hpp"
if (directiveExists(config.second[0].first, "listen")) // necessary to avoid runtime_error
    getFirstDirective(config.second[0].first, "listen");
// check may be avoided if the key is guaranteed to be there, as it is the case with directives that have default values
```
- This is necessary, because directives can now have multiple values, which is why there is a 3rd function:
```c++
getAllDirectives(config.second[0].first, "listen"); // returns a vector of Arguments.
```
- this vector can be iterated over, and each element in the vector is a vector of strings (aka `Arguments`) for the specific `listen` directive (or any other directive
- if the directive is not in the multimap, the result will be an empty vector
- there is a typedef `ArgResults` which is the same as `vector<vector<string>>` for convenience.