### PR TITLE
Validate multi directives

### DIFF
--- a/SubjectRequirementsForConfig.txt
+++ b/SubjectRequirementsForConfig.txt
@@ -46,7 +46,7 @@
 6.2 define a http redirection
 	- location.return
 	- default: none
-	- multiple: yes
+	- multiple: no // although nginx allows for multiple
 	- https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return
 
 6.3 define a directory or a file from where the file should be searched

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,8 +1,9 @@
 root html;
 
 server {
-	listen 0x7f.0.0.1:8080;
-	server_name "server1";
+	# listen 0x7f.0.0.1:8080;
+	listen 127.0.0.1:8080;
+	server_name a;
 
 	root html/server1;
 
@@ -15,7 +16,9 @@ server {
 
 server {
 	listen 127.0.0.1:8081;
-	server_name server2;
+	server_name b;
+	server_name d a;
+	server_name c;
 
 	root html/server2;
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -38,9 +38,9 @@ const Arguments& getFirstDirective(const Directives& directives, const string& d
 	return result_itr->second;
 }
 
-std::vector<Arguments> getAllDirectives(const Directives& directives, const string& directive) {
+ArgResults getAllDirectives(const Directives& directives, const string& directive) {
 	std::pair<Directives::const_iterator, Directives::const_iterator> result_itr = directives.equal_range(directive);
-	std::vector<Arguments> allArgs;
+	ArgResults allArgs;
 
 	for (Directives::const_iterator it = result_itr.first; it != result_itr.second; ++it) {
 		allArgs.push_back(it->second);
@@ -268,16 +268,6 @@ static void updateDefaults(Config& config) {
 		populateDefaultServerDirectives(server->first, config.first);
 		for (LocationCtxs::iterator location = server->second.begin(); location != server->second.end(); ++location) {
 			populateDefaultLocationDirectives(location->second, server->first);
-		}
-	}
-}
-
-static void checkDirectives(Config& config) {
-	checkHttpDirectives(config.first);
-	for (ServerCtxs::iterator server = config.second.begin(); server != config.second.end(); ++server) {
-		checkServerDirectives(server->first);
-		for (LocationCtxs::iterator location = server->second.begin(); location != server->second.end(); ++location) {
-			checkLocationDirectives(location->second);
 		}
 	}
 }

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -15,6 +15,8 @@ typedef std::pair<Directives, LocationCtxs> ServerCtx;
 typedef std::vector<ServerCtx> ServerCtxs;
 typedef std::pair<Directives, ServerCtxs> Config;
 
+typedef std::vector<Arguments> ArgResults;
+
 enum TokenType {
 	TOK_SEMICOLON,
 	TOK_OPENING_BRACE,
@@ -33,4 +35,4 @@ Config parseConfig(std::string rawConfig);
 
 bool directiveExists(const Directives& directives, const std::string& directive);
 const Arguments& getFirstDirective(const Directives& directives, const std::string& directive);
-std::vector<Arguments> getAllDirectives(const Directives& directives, const std::string& directive);
+ArgResults getAllDirectives(const Directives& directives, const std::string& directive);

--- a/src/DirectiveValidation.cpp
+++ b/src/DirectiveValidation.cpp
@@ -17,16 +17,12 @@
 #include "Constants.hpp"
 #include "Utils.hpp"
 
-#define CHECKFN_HTTP(checkFunction) \
-	if (checkFunction("http", directive, arguments) && ++counts[directive] <= 1) \
+#define CHECKFN(ctx, checkFunction) \
+	if (checkFunction(ctx, directive, arguments) && ++counts[directive] <= 1) \
 		continue
 
-#define CHECKFN_SERVER(checkFunction) \
-	if (checkFunction("server", directive, arguments) && ++counts[directive] <= 1) \
-		continue
-
-#define CHECKFN_LOCATION(checkFunction) \
-	if (checkFunction("location", directive, arguments) && ++counts[directive] <= 1) \
+#define CHECKFN_MULTI(ctx, checkFunction) \
+	if (checkFunction(ctx, directive, arguments)) \
 		continue
 
 using std::map;
@@ -283,15 +279,14 @@ static void checkHttpDirectives(Directives& directives) {
 	for (Directives::iterator kv = directives.begin(); kv != directives.end(); ++kv) {
 		const string& directive = kv->first;
 		Arguments& arguments = kv->second;
-		CHECKFN_HTTP(checkAutoindex);
-		CHECKFN_HTTP(checkCgiDir);
-		CHECKFN_HTTP(checkCgiExt);
-		CHECKFN_HTTP(checkClientMaxBodySize);
-		CHECKFN_HTTP(checkErrorPage);
-		CHECKFN_HTTP(checkIndex);
-		CHECKFN_HTTP(checkRoot);
-		CHECKFN_HTTP(checkRoot);
-		CHECKFN_HTTP(checkUploadDir);
+		CHECKFN      ("http", checkAutoindex);
+		CHECKFN      ("http", checkCgiDir);
+		CHECKFN_MULTI("http", checkCgiExt);
+		CHECKFN      ("http", checkClientMaxBodySize);
+		CHECKFN_MULTI("http", checkErrorPage);
+		CHECKFN_MULTI("http", checkIndex);
+		CHECKFN      ("http", checkRoot);
+		CHECKFN      ("http", checkUploadDir);
 		if (counts[directive] > 1)
 			throw runtime_error(Errors::Config::DirectiveNotUnique("http", directive));
 		throw runtime_error(Errors::Config::UnknownDirective("http", directive));
@@ -303,16 +298,16 @@ static void checkServerDirectives(Directives& directives) {
 	for (Directives::iterator kv = directives.begin(); kv != directives.end(); ++kv) {
 		const string& directive = kv->first;
 		Arguments& arguments = kv->second;
-		CHECKFN_SERVER(checkAutoindex);
-		CHECKFN_SERVER(checkCgiDir);
-		CHECKFN_SERVER(checkCgiExt);
-		CHECKFN_SERVER(checkClientMaxBodySize);
-		CHECKFN_SERVER(checkErrorPage);
-		CHECKFN_SERVER(checkIndex);
-		CHECKFN_SERVER(checkListen);
-		CHECKFN_SERVER(checkRoot);
-		CHECKFN_SERVER(checkServerName);
-		CHECKFN_SERVER(checkUploadDir);
+		CHECKFN      ("server", checkAutoindex);
+		CHECKFN      ("server", checkCgiDir);
+		CHECKFN_MULTI("server", checkCgiExt);
+		CHECKFN      ("server", checkClientMaxBodySize);
+		CHECKFN_MULTI("server", checkErrorPage);
+		CHECKFN_MULTI("server", checkIndex);
+		CHECKFN_MULTI("server", checkListen);
+		CHECKFN      ("server", checkRoot);
+		CHECKFN_MULTI("server", checkServerName);
+		CHECKFN      ("server", checkUploadDir);
 		if (counts[directive] > 1)
 			throw runtime_error(Errors::Config::DirectiveNotUnique("server", directive));
 		throw runtime_error(Errors::Config::UnknownDirective("server", directive));
@@ -324,17 +319,17 @@ static void checkLocationDirectives(Directives& directives) {
 	for (Directives::iterator kv = directives.begin(); kv != directives.end(); ++kv) {
 		const string& directive = kv->first;
 		Arguments& arguments = kv->second;
-		CHECKFN_LOCATION(checkAlias);
-		CHECKFN_LOCATION(checkAutoindex);
-		CHECKFN_LOCATION(checkCgiDir);
-		CHECKFN_LOCATION(checkCgiExt);
-		CHECKFN_LOCATION(checkClientMaxBodySize);
-		CHECKFN_LOCATION(checkErrorPage);
-		CHECKFN_LOCATION(checkIndex);
-		CHECKFN_LOCATION(checkLimitExcept);
-		CHECKFN_LOCATION(checkReturn);
-		CHECKFN_LOCATION(checkRoot);
-		CHECKFN_LOCATION(checkUploadDir);
+		CHECKFN      ("location", checkAlias);
+		CHECKFN      ("location", checkAutoindex);
+		CHECKFN      ("location", checkCgiDir);
+		CHECKFN_MULTI("location", checkCgiExt);
+		CHECKFN      ("location", checkClientMaxBodySize);
+		CHECKFN_MULTI("location", checkErrorPage);
+		CHECKFN_MULTI("location", checkIndex);
+		CHECKFN      ("location", checkLimitExcept);
+		CHECKFN      ("location", checkReturn);
+		CHECKFN      ("location", checkRoot);
+		CHECKFN      ("location", checkUploadDir);
 		if (counts[directive] > 1)
 			throw runtime_error(Errors::Config::DirectiveNotUnique("location", directive));
 		throw runtime_error(Errors::Config::UnknownDirective("location", directive));

--- a/src/DirectiveValidation.hpp
+++ b/src/DirectiveValidation.hpp
@@ -2,6 +2,4 @@
 
 #include "Config.hpp"
 
-void checkHttpDirectives(Directives& directives);
-void checkServerDirectives(Directives& directives);
-void checkLocationDirectives(Directives& directives);
+void checkDirectives(Config& config);


### PR DESCRIPTION
This PR is 2 commits (fast-forward) ahead of #7, so #7 should be merged first.

# Main feature:
- validate semantics of those directive which may be specified multiple times (not hard anymore with multimap)
- validate semantics of the listen + server_name directives, which is not trivial at all, see this example:
```nginx
server {
  listen 127.0.0.1:8080;
  listen 127.0.0.2:8080;
  server_name a;
}
server {
  listen 127.0.0.3:8080;
  listen 127.0.0.2:8081;
  server_name b;
  server_name c a;
  server_name d;
}
```
- the above should be fine, while the below should fail
```nginx
server {
  listen 127.0.0.1:8080;
  listen 127.0.0.2:8080;
  server_name a;
}
server {
  listen 127.0.0.3:8080;
  listen 127.0.0.2:8080; # <-- note the change from above
  server_name b;
  server_name c a;
  server_name d;
}
```
- because now the two servers listen on the same host:port AND there's an overlapping server_name. the failing config becomes good again when we remove the `a` server_name.