### PR TITLE
Remove fcntl, Add checking for write at the same time with read

### DIFF
--- a/src/Reflection.cpp
+++ b/src/Reflection.cpp
@@ -12,11 +12,11 @@ using std::swap;
 
 static string _replace(string s, const string& search, const string& replace) {
 	std::size_t pos = 0;
-    while ((pos = s.find(search, pos)) != string::npos) {
-         s.replace(pos, search.length(), replace);
-         pos += replace.length();
-    }
-    return s;
+	while ((pos = s.find(search, pos)) != string::npos) {
+		 s.replace(pos, search.length(), replace);
+		 pos += replace.length();
+	}
+	return s;
 }
 
 static string jsonEscape(string s) {


### PR DESCRIPTION
## Key features

- Added write, works at the same time with read
- removed fcntl, literally added SOCK_NONBLOCK to socket() and it works :D 

- tested with siege, due to adding write, results are improved but not ideal:

```
siege -b -t30S -v http://localhost:8087/

{    "transactions":                  130369,
    "availability":                   99.22,
    "elapsed_time":                    9.36,
    "data_transferred":                6.34,
    "response_time":                0.00,
    "transaction_rate":            13928.31,
    "throughput":                    0.68,
    "concurrency":                   24.17,
    "successful_transactions":          130369,
    "failed_transactions":                1024,
    "longest_transaction":                0.02,
    "shortest_transaction":                0.00
}
```

I have some ideas on how to improve it even more, but for now I'd like to finish main functionality on our server
