### PR TITLE
Handle limit_except directive

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -44,7 +44,7 @@ server {
 
 	autoindex on;
 	location / {
-		limit_except POST;
+		limit_except GET DELETE;
 	}
 	location /alias/ {
 		alias /some-folder/;

--- a/src/HttpServer/HttpServer.hpp
+++ b/src/HttpServer/HttpServer.hpp
@@ -217,6 +217,7 @@ private:
 	// request handling
 	void handleRequest(int clientSocket, const HttpRequest& request, const LocationCtx& location);
 	void handleRequestInternally(int clientSocket, const HttpRequest& request, const LocationCtx& location);
+	bool methodAllowed(const HttpRequest& request, const LocationCtx& location);
 	
 	// static file serving
 	void serveStaticContent(int clientSocket, const HttpRequest& request, const LocationCtx& location);


### PR DESCRIPTION
If a method does not exactly match (case sensitive) one of the methods specified in limit_except, send a 405 method not allowed (same error when you use an invalid method).