### PR TITLE
Return directive (and fixing lexing of strings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ a.c
 a.out
 webserv
 c2_unit_tests
+Catch2
 
 # coverage artefacts
 *.profraw

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CFLAGS += -Wconversion
 CFLAGS += -Wunreachable-code
 CFLAGS += -std=c++98
 CFLAGS += -MMD
-#CFLAGS += -pedantic # Mhhhh maybe don't put this flag, see `-Wno-...' flag below :) # TODO: @all: Remove this and comment to the left
+#CFLAGS += -pedantic # Mhhhh don't put this flag, see `-Wno-...' flag below :) # TODO: @all: Remove this and comment to the left
 #CFLAGS += -Wno-variadic-macros # C++98 doesn't have variadic macros. Also, emtpy macro argument are UB. But yeahhhh we don't have to be pedantic :))
 
 CFLAGS += -fdiagnostics-color=always

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -33,6 +33,12 @@ server {
 	location /delete_dir/ {
 		autoindex on;
 	}
+	location /secret {
+		return 200 "SOME RANDOM TEXT\n";
+	}
+	location /google/ {
+		return 301 https://www.google.com;
+	}
 }
 
 server {

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -262,17 +262,28 @@ static void updateTokenType(Tokens& tokens) {
 		tokens.back().first = TOK_WORD;
 }
 
+static bool updateQuoted(bool& quoted, const string& stringSoFar) {
+	bool isRealQuote = DirectiveValidation::evenNumberOfBackslashes(stringSoFar, stringSoFar.length() - 1);
+	if (isRealQuote) {
+		quoted = !quoted;
+		return true;
+	}
+	return false;
+}
+
 static Tokens lexConfig(string rawConfig) {
 	Tokens tokens;
 	char c;
 	char prevC;
 	bool createNewToken = true;
+	bool quoted = false;
 	
 	rawConfig = removeComments(rawConfig);
 	prevC = '\0';
 	for (std::string::iterator it = rawConfig.begin(); it != rawConfig.end(); ++it) {
 		c = *it;
-		if (isspace(c) || c == ';' || c == '{' || c == '}' || prevC == ';' || prevC == '{' || prevC == '}') {
+		if (!quoted && (    isspace(c) ||     c == '"' ||     c == ';' ||     c == '{' ||     c == '}' ||
+						isspace(prevC) || prevC == '"' || prevC == ';' || prevC == '{' || prevC == '}')) {
 			if (!tokens.empty()) {
 				createNewToken = true;
 				updateTokenType(tokens);
@@ -286,6 +297,9 @@ static Tokens lexConfig(string rawConfig) {
 			tokens.push_back(newToken(TOK_UNKNOWN, ""));
 			createNewToken = false;
 		}
+
+		if (c == '"')
+			(void)updateQuoted(quoted, tokens.back().second);
 		tokens.back().second += c;
 	}
 	return tokens;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -315,7 +315,7 @@ Config parseConfig(string rawConfig) {
 
 	updateDefaults(config);
 
-	checkDirectives(config);
+	DirectiveValidation::checkDirectives(config);
 
 	if (config.second.empty())
 		throw runtime_error(Errors::Config::ZeroServers());

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -6,10 +6,12 @@
 #include <deque>
 #include <string>
 
-typedef std::vector<std::string> Arguments;
-typedef std::pair<std::string, Arguments> Directive;
-typedef std::multimap<std::string, Arguments> Directives;
-typedef std::pair<std::string, Directives> LocationCtx;
+using std::string;
+
+typedef std::vector<string> Arguments;
+typedef std::pair<string, Arguments> Directive;
+typedef std::multimap<string, Arguments> Directives;
+typedef std::pair<string, Directives> LocationCtx;
 typedef std::vector<LocationCtx> LocationCtxs;
 typedef std::pair<Directives, LocationCtxs> ServerCtx;
 typedef std::vector<ServerCtx> ServerCtxs;
@@ -27,12 +29,12 @@ enum TokenType {
 };
 typedef enum TokenType TokenType;
 
-typedef std::pair<TokenType, std::string> Token;
+typedef std::pair<TokenType, string> Token;
 typedef std::deque<Token> Tokens;
 
-std::string readConfig(std::string configPath);
-Config parseConfig(std::string rawConfig);
+string readConfig(string configPath);
+Config parseConfig(string rawConfig);
 
-bool directiveExists(const Directives& directives, const std::string& directive);
-const Arguments& getFirstDirective(const Directives& directives, const std::string& directive);
-ArgResults getAllDirectives(const Directives& directives, const std::string& directive);
+bool directiveExists(const Directives& directives, const string& directive);
+const Arguments& getFirstDirective(const Directives& directives, const string& directive);
+ArgResults getAllDirectives(const Directives& directives, const string& directive);

--- a/src/DirectiveValidation.cpp
+++ b/src/DirectiveValidation.cpp
@@ -52,7 +52,7 @@ static inline void ensureNotEmpty(const string& ctx, const string& directive, co
 		throw runtime_error(Errors::Config::DirectiveArgumentEmpty(ctx, directive));
 }
 
-static inline bool evenNumberOfBackslashes(const string& str, size_t endingAt) {
+bool DirectiveValidation::evenNumberOfBackslashes(const string& str, size_t endingAt) {
 	int count = 0;
 	for (int i = static_cast<int>(endingAt); i >= 0; --i) {
 		if (str[static_cast<size_t>(i)] == '\\')

--- a/src/DirectiveValidation.hpp
+++ b/src/DirectiveValidation.hpp
@@ -7,4 +7,5 @@ namespace DirectiveValidation {
 	bool isHttpUri(const string& str);
 	bool isDoubleQuoted(const string& str);
 	string decodeDoubleQuotedString(const string& str);
+	bool evenNumberOfBackslashes(const string& str, size_t endingAt);
 }

--- a/src/DirectiveValidation.hpp
+++ b/src/DirectiveValidation.hpp
@@ -2,4 +2,9 @@
 
 #include "Config.hpp"
 
-void checkDirectives(Config& config);
+namespace DirectiveValidation {
+	void checkDirectives(Config& config);
+	bool isHttpUri(const string& str);
+	bool isDoubleQuoted(const string& str);
+	string decodeDoubleQuotedString(const string& str);
+}

--- a/src/Errors.cpp
+++ b/src/Errors.cpp
@@ -99,3 +99,11 @@ const string Errors::Config::UnknownDirective(const string& ctx, const string& d
 const string Errors::Config::ZeroServers() {
 	return CONFIG_ERROR_PREFIX((char*)"http") + cmt("There must be at least one ") + repr((char*)"server") + cmt(" directive");
 }
+
+const string Errors::Config::DirectiveArgumentInvalidDoubleQuotedString(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("String argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+}
+
+const string Errors::Config::DirectiveArgumentInvalidHttpUri(const string& ctx, const string& directive, const string& argument) {
+	return CONFIG_ERROR_PREFIX(ctx) + cmt("HTTP URI argument ") + repr(argument) + cmt(" for directive ") + repr(directive) + cmt(" is invalid");
+}

--- a/src/Errors.hpp
+++ b/src/Errors.hpp
@@ -30,6 +30,7 @@ namespace Errors {
 		const string InvalidDirectiveArgumentCount(const string& ctx, const string& directive, int count, int min, int max);
 		const string UnknownDirective(const string& ctx, const string& directive);
 		const string ZeroServers();
+		const string DirectiveArgumentInvalidHttpUri(const string& ctx, const string& directive, const string& argument);
+		const string DirectiveArgumentInvalidDoubleQuotedString(const string& ctx, const string& directive, const string& argument);
 	}
 }
-

--- a/src/HttpServer/GetRequestHandling.cpp
+++ b/src/HttpServer/GetRequestHandling.cpp
@@ -1,16 +1,19 @@
 #include "Config.hpp"
 #include "HttpServer.hpp"
 
+void HttpServer::redirectClient(int clientSocket, const string& newUri, int statusCode) {
+	std::ostringstream response;
+	response << _httpVersionString << " " << statusCode << " " << statusTextFromCode(statusCode) << "\r\n"
+			<< "Location: " << newUri << "\r\n"
+			<< "Connection: close\r\n\r\n";
+	string responseStr = response.str();
+	send(clientSocket, responseStr.c_str(), responseStr.length(), 0);
+	removeClient(clientSocket);
+}
+
 bool HttpServer::handleDirectoryRedirect(int clientSocket, const string& uri) {
 		if (uri[uri.length() - 1] != '/') {
-			string redirectUri = uri + "/";
-			std::ostringstream response;
-			response << _httpVersionString << " " << 301 << " " << statusTextFromCode(301) << "\r\n"
-					<< "Location: " << redirectUri << "\r\n"
-					<< "Connection: close\r\n\r\n";
-			string responseStr = response.str();
-			send(clientSocket, responseStr.c_str(), responseStr.length(), 0);
-			removeClient(clientSocket);
+			redirectClient(clientSocket, uri + "/");
 			return true;
 		}
 		return false;

--- a/src/HttpServer/HttpServer.hpp
+++ b/src/HttpServer/HttpServer.hpp
@@ -148,6 +148,8 @@ public:
 		
 		CGIProcess(pid_t p, int fd, int client, const LocationCtx* loc) : 
 			pid(p), pipe_fd(fd), response(), totalSize(0), clientSocket(client), location(loc), headersSent(false), pollCycles(0) {}
+		CGIProcess(const CGIProcess& other) : pid(other.pid), pipe_fd(other.pipe_fd), response(other.response), totalSize(other.totalSize), clientSocket(other.clientSocket), location(other.location), headersSent(other.headersSent), pollCycles(other.pollCycles) { (void)other; }
+		CGIProcess& operator=(const CGIProcess&) { return *this; }
 };
 
 	const vector<int>&				get_listeningSockets()	const { return _listeningSockets; }
@@ -186,11 +188,11 @@ private:
 
 	//// private methods ////
 	// HttpServer must always be constructed with a config
-	HttpServer() : _listeningSockets(), _monitorFds(Constants::defaultMultPlexType), _pollFds(_monitorFds.pollFds), _httpVersionString(), _rawConfig(), _config(), _mimeTypes(), _statusTexts(), _pendingWrites(), _pendingCloses(), _servers(), _defaultServers() {};
+	HttpServer() : _listeningSockets(), _monitorFds(Constants::defaultMultPlexType), _pollFds(_monitorFds.pollFds), _httpVersionString(), _rawConfig(), _config(), _mimeTypes(), _statusTexts(), _pendingWrites(), _pendingCloses(), _servers(), _defaultServers(), _cgiProcesses() {};
 	// Copying HttpServer is forbidden, since that would violate the 1-1 mapping between a server and its config
-	HttpServer(const HttpServer& other) : _listeningSockets(), _monitorFds(Constants::defaultMultPlexType), _pollFds(_monitorFds.pollFds), _httpVersionString(), _rawConfig(), _config(), _mimeTypes(), _statusTexts(), _pendingWrites(), _pendingCloses(), _servers(), _defaultServers() { (void)other; };
+	HttpServer(const HttpServer&) : _listeningSockets(), _monitorFds(Constants::defaultMultPlexType), _pollFds(_monitorFds.pollFds), _httpVersionString(), _rawConfig(), _config(), _mimeTypes(), _statusTexts(), _pendingWrites(), _pendingCloses(), _servers(), _defaultServers(), _cgiProcesses() {};
 	// HttpServer cannot be assigned to
-	HttpServer& operator=(HttpServer) { return *this; };
+	HttpServer& operator=(const HttpServer&) { return *this; };
 
 	// Setup
 	void setupServers(const Config& config);

--- a/src/HttpServer/HttpServer.hpp
+++ b/src/HttpServer/HttpServer.hpp
@@ -166,7 +166,7 @@ public:
 	const DefaultServers&			get_defaultServers()	const { return _defaultServers; }
 	map<int, CGIProcess>& 			get_CGIProcesses()		{ return _cgiProcesses; }
 	MultPlexFds&					get_MonitorFds()		{ return _monitorFds; }
-	void sendError(int clientSocket, int statusCode, const LocationCtx *const location = NULL);
+	void sendError(int clientSocket, int statusCode, const LocationCtx *const location);
 
 private:
 	//// private members ////
@@ -225,6 +225,8 @@ private:
 	void handleRequestInternally(int clientSocket, const HttpRequest& request, const LocationCtx& location);
 	bool methodAllowed(const HttpRequest& request, const LocationCtx& location);
 	void handleDelete(int clientSocket, const HttpRequest& request, const LocationCtx& location);
+	void rewriteRequest(int clientSocket, int statusCode, const string& urlOrText, const LocationCtx& location);
+	void redirectClient(int clientSocket, const string& newUri, int statusCode = 301);
 	
 	// static file serving
 	void serveStaticContent(int clientSocket, const HttpRequest& request, const LocationCtx& location);

--- a/src/HttpServer/LocationMatching.cpp
+++ b/src/HttpServer/LocationMatching.cpp
@@ -80,7 +80,7 @@ struct sockaddr_in HttpServer::getSockaddrIn(int clientSocket) {
 	socklen_t addrLen = sizeof(addr);
 	if (getsockname(clientSocket, (struct sockaddr*)&addr, &addrLen) < 0) {
 		int prev_errno = errno;
-		sendError(clientSocket, 500);
+		sendError(clientSocket, 500, NULL);
 		throw runtime_error(string("getsockname failed: ") + strerror(prev_errno));
 	}
 	return addr;
@@ -95,7 +95,7 @@ const LocationCtx& HttpServer::requestToLocation(int clientSocket, const HttpReq
 	// find server by matching against host, addr, and port
 	size_t serverIdx;
 	if (!(serverIdx = findMatchingServer(host, addr.sin_addr, addr.sin_port))) {
-		sendError(clientSocket, 404); // TODO: @all: is 404 rlly correct?
+		sendError(clientSocket, 404, NULL); // TODO: @all: is 404 rlly correct?
 		throw runtime_error(string("couldn't find a server for hostname '") + host + "' and addr:port being " + STR(ntohl(addr.sin_addr.s_addr)) + ":" + STR(ntohs(addr.sin_port)));
 	}
 	const Server& server = _servers[serverIdx - 1]; // serverIdx=0 indicates failure, so 1 is the first server
@@ -103,7 +103,7 @@ const LocationCtx& HttpServer::requestToLocation(int clientSocket, const HttpReq
 	// find location by matching against request uri
 	size_t locationIdx;
 	if (!(locationIdx = findMatchingLocation(server, request.path))) {
-		sendError(clientSocket, 404); // TODO: @all: is 404 rlly correct?
+		sendError(clientSocket, 404, NULL); // TODO: @all: is 404 rlly correct?
 		throw runtime_error(string("couldn't find a location for URI '") + request.path + "'");
 	}
 	return server.locations[locationIdx - 1]; // TODO: @all: we need a default location at "/" that has all the server's directives

--- a/src/HttpServer/RequestHandling.cpp
+++ b/src/HttpServer/RequestHandling.cpp
@@ -123,7 +123,7 @@ HttpServer::HttpRequest HttpServer::parseHttpRequest(const char *buffer) {
 
 void HttpServer::handleDelete(int clientSocket, const HttpRequest& request, const LocationCtx& location) {
 	if (!directiveExists(location.second, "upload_dir"))
-		sendError(clientSocket, 405);
+		sendError(clientSocket, 405, NULL);
 	string diskPath = determineDiskPath(request, location);
 
 	struct stat fileStat;
@@ -158,7 +158,9 @@ void HttpServer::handleRequestInternally(int clientSocket, const HttpRequest& re
 }
 
 bool HttpServer::methodAllowed(const HttpRequest& request, const LocationCtx& location) {
-	if (!directiveExists(location.second, "limit_except"))
+	if (!Utils::allUppercase(request.method))
+		return false;
+	else if (!directiveExists(location.second, "limit_except"))
 		return true;
 	const Arguments& allowedMethods = getFirstDirective(location.second, "limit_except");
 	for (Arguments::const_iterator method = allowedMethods.begin(); method != allowedMethods.end(); ++method) {

--- a/src/HttpServer/ResponseSending.cpp
+++ b/src/HttpServer/ResponseSending.cpp
@@ -113,6 +113,7 @@ bool HttpServer::sendErrorPage(int clientSocket, int statusCode, const LocationC
 	return sendFileContent(clientSocket, errorPagePath, location, statusCode);
 }
 
+// pass NULL as location if errorPages should not be served
 void HttpServer::sendError(int clientSocket, int statusCode, const LocationCtx *const location) {
 	if (location == NULL || !sendErrorPage(clientSocket, statusCode, *location))
 		sendString(clientSocket, wrapInHtmlBody("<h1>\r\n\t\t\t" + STR(statusCode) + " " + statusTextFromCode(statusCode) + "\r\n\t\t</h1>"), statusCode);

--- a/src/Reflection.cpp
+++ b/src/Reflection.cpp
@@ -4,22 +4,10 @@
 
 #include "Reflection.hpp"
 #include "Repr.hpp"
+#include "Utils.hpp"
 
 using std::string;
 using std::swap;
-
-static inline string _replace(string s, const string& search, const string& replace) {
-	size_t pos = 0;
-	while ((pos = s.find(search, pos)) != string::npos) {
-		 s.replace(pos, search.length(), replace);
-		 pos += replace.length();
-	}
-	return s;
-}
-
-static inline string jsonEscape(string s) {
-	return _replace(_replace(s, "\\", "\\\\"), "\"", "\\\"");
-}
 
 Reflection::Reflection() : _class(), _members() {}
 Reflection::Reflection(const Reflection& other) : _class(other._class), _members(other._members) {}
@@ -32,7 +20,7 @@ void swap(Reflection& a, Reflection& b) { a.swap(b); }
 string Reflection::reprStruct(string name, Members members, bool json) const {
 	std::stringstream out;
 	if (json || Constants::jsonTrace) {
-		out << "{\"class\":\"" << jsonEscape(name) << "\"";
+		out << "{\"class\":\"" << Utils::jsonEscape(name) << "\"";
 		for (Members::const_iterator it = members.begin(); it != members.end(); ++it)
 			out << ",\"" << it->first << "\":" << (this->*it->second.first)(true);
 		out << "}";

--- a/src/Repr.hpp
+++ b/src/Repr.hpp
@@ -12,6 +12,7 @@
 #include "Constants.hpp"
 #include "Ansi.hpp"
 #include "Reflection.hpp"
+#include "Utils.hpp"
 
 # define ANSI_FG     "41;41;41"
 # define ANSI_STR    "184;187;38"
@@ -134,27 +135,25 @@ template <> struct ReprWrapper<bool> {
 	}
 };
 
-// TODO: @timo: escape for string literal
 template <>
 struct ReprWrapper<string> {
 	static inline string
 	repr(const string& value, bool json = false) {
 		if (json)
-			return "\"" + value + "\"";
+			return "\"" + Utils::jsonEscape(value) + "\"";
 		else
-			return str("\"" + value + "\"") + (Constants::verboseLogs ? punct("s") : "");
+			return str("\"" + Utils::jsonEscape(value) + "\"") + (Constants::verboseLogs ? punct("s") : "");
 	}
 };
 
-// TODO: @timo: escape for string literal
 template <> 
 struct ReprWrapper<char*> {
 	static inline string
 	repr(const char* const& value, bool json = false) {
 		if (json)
-			return string("\"") + value + "\"";
+			return string("\"") + Utils::jsonEscape(value) + "\"";
 		else
-			return str(string("\"") + value + "\"");
+			return str(string("\"") + Utils::jsonEscape(value) + "\"");
 	}
 };
 
@@ -178,9 +177,9 @@ struct ReprWrapper<T*> {
 		static inline string \
 		repr(const T& value, bool json = false) { \
 			if (json) \
-				return string("\"") + static_cast<char>(value) + "\""; \
+				return string("\"") + Utils::jsonEscape(string(1, value)) + "\""; \
 			else \
-				return chr(string("'") + static_cast<char>(value) + "'"); \
+				return chr(string("'") + (value == '\\' ? "\\\\" : value == '\'' ? "\\'" : string(1, value)) + "'"); \
 		} \
 	}
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -60,3 +60,16 @@ bool Utils::isHexDigitNoCase(const char c) {
 		return true;
 	return false;
 }
+
+string Utils::replaceAll(string s, const string& search, const string& replace) {
+	size_t pos = 0;
+	while ((pos = s.find(search, pos)) != string::npos) {
+		 s.replace(pos, search.length(), replace);
+		 pos += replace.length();
+	}
+	return s;
+}
+
+string Utils::jsonEscape(string s) {
+	return Utils::replaceAll(Utils::replaceAll(s, "\\", "\\\\"), "\"", "\\\"");
+}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -73,3 +73,11 @@ string Utils::replaceAll(string s, const string& search, const string& replace) 
 string Utils::jsonEscape(string s) {
 	return Utils::replaceAll(Utils::replaceAll(s, "\\", "\\\\"), "\"", "\\\"");
 }
+
+bool Utils::allUppercase(const string& str) {
+	for (size_t i = 0; i < str.length(); ++i) {
+		if (str[i] < 'A' || str[i] > 'Z')
+			return false;
+	}
+	return true;
+}

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -15,6 +15,8 @@ namespace Utils {
 	string strToLower(const string& str);
 	char decodeTwoHexChars(const char _c1, const char _c2);
 	bool isHexDigitNoCase(const char c);
+	string replaceAll(string s, const string& search, const string& replace);
+	string jsonEscape(string s);
 
 	template<typename T>
 	static inline vector<T>& getTmpVec() {

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -17,6 +17,7 @@ namespace Utils {
 	bool isHexDigitNoCase(const char c);
 	string replaceAll(string s, const string& search, const string& replace);
 	string jsonEscape(string s);
+	bool allUppercase(const string& str);
 
 	template<typename T>
 	static inline vector<T>& getTmpVec() {

--- a/tools/check_maybe.sh
+++ b/tools/check_maybe.sh
@@ -21,10 +21,10 @@ highlight_tags () {
 }
 
 remove_todo_color () {
-	sed -e "s/\\[01;31m\\[K[Tt][Oo][Dd][Oo]\\[m\\[K/TODO/g"
+	sed -e "s/\\[01;31m\\[K[Mm][Aa][Yy][Bb][Ee]\\[m\\[K/MAYBE/g"
 }
 
 grep --color=always \
 	--exclude-dir=.git/ \
 	--exclude-dir=Catch2/ \
-	-IinR -- '\<[T]ODO\>' "$(git rev-parse --show-toplevel)" | grep -v 'src/\.gitignore' | remove_todo_color | grep -v -e '_TODO_' -e '/TODO/' | highlight_tags
+	-IinR -- '\<[M]AYBE\>' "$(git rev-parse --show-toplevel)" | grep -v 'src/\.gitignore' | remove_todo_color | grep -v -e '_MAYBE_' -e '/MAYBE/' | highlight_tags

--- a/tools/gcovr.sh
+++ b/tools/gcovr.sh
@@ -15,7 +15,7 @@ warn () {
 top_level="$(git rev-parse --show-toplevel)" || die "Failed to obtain root of git repository"
 cd -- "${top_level}" || die "Failed to change directory to '${top_level}'"
 
-1>/dev/null 2>/dev/null command -v gcovr || die "gcovr is not installed, install gcovr, or look at https://command-not-found.com/gcovr"
+1>/dev/null 2>/dev/null command -v gcovr || die "gcovr is not installed, install gcovr, or look at https://command-not-found.com/gcovr, or run this command:$(printf '\n\n\t')pip install gcovr (might need to add --break-system-packages)"
 
 GCOVR_OUT_DIR="gcovr_report"
 [ "$(printf %s "${GCOVR_OUT_DIR}" | tr -d '/')" = "${GCOVR_OUT_DIR}" ] || die "GCOVR_OUT_DIR (${GCOVR_OUT_DIR}) variable is probably unsafe because it contains a slash"
@@ -23,7 +23,7 @@ GCOVR_OUT_DIR="gcovr_report"
 [ -e "${GCOVR_OUT_DIR}" ] && ([ -d "${GCOVR_OUT_DIR}" ] || die "GCOVR_OUT_DIR (${GCOVR_OUT_DIR}) exists and is not a directory") 
 
 export DEBUG=1
-export CXX='g++'
+export _CXX='g++'
 export CFLAGS='-fprofile-arcs -ftest-coverage'
 export LDFLAGS='-fprofile-arcs -ftest-coverage'
 

--- a/tools/lcov.sh
+++ b/tools/lcov.sh
@@ -15,8 +15,8 @@ warn () {
 top_level="$(git rev-parse --show-toplevel)" || die "Failed to obtain root of git repository"
 cd -- "${top_level}" || die "Failed to change directory to '${top_level}'"
 
-1>/dev/null 2>/dev/null command -v lcov || die "lcov is not installed, install lcov, or look at https://command-not-found.com/genhtml"
-1>/dev/null 2>/dev/null command -v genhtml || die "genhtml is not installed, install lcov, or look at https://command-not-found.com/genhtml"
+1>/dev/null 2>/dev/null command -v lcov || die "lcov is not installed, install lcov, or look at https://command-not-found.com/genhtml, or run this command:$(printf '\n\n\t')git clone https://github.com/linux-test-project/lcov && cd lcov && mkdir -p \"$HOME/.local\" && make install PREFIX=\"$HOME/.local\" && rm -rf ./lcov && echo 'Installed lcov, restart your shell'"
+1>/dev/null 2>/dev/null command -v genhtml || die "genhtml is not installed, install lcov, or look at https://command-not-found.com/genhtml, or run this command:$(printf '\n\n\t')git clone https://github.com/linux-test-project/lcov && cd lcov && mkdir -p \"$HOME/.local\" && make install PREFIX=\"$HOME/.local\" && rm -rf ./lcov && echo 'Installed lcov, restart your shell'"
 
 LCOV_OUT_DIR="lcov_report"
 [ "$(printf %s "${LCOV_OUT_DIR}" | tr -d '/')" = "${LCOV_OUT_DIR}" ] || die "LCOV_OUT_DIR (${LCOV_OUT_DIR}) variable is probably unsafe because it contains a slash"
@@ -24,7 +24,7 @@ LCOV_OUT_DIR="lcov_report"
 [ -e "${LCOV_OUT_DIR}" ] && ([ -d "${LCOV_OUT_DIR}" ] || die "LCOV_OUT_DIR (${LCOV_OUT_DIR}) exists and is not a directory")
 
 export DEBUG=1
-export CXX='g++'
+export _CXX='g++'
 export CFLAGS='-fprofile-arcs -ftest-coverage'
 export LDFLAGS='-fprofile-arcs -ftest-coverage'
 

--- a/tools/llvmcov.sh
+++ b/tools/llvmcov.sh
@@ -24,11 +24,9 @@ LLVM_PROFDATA_DIR="llvm_profdata"
 [ -e "${LLVM_PROFDATA_DIR}" ] && ([ -d "${LLVM_PROFDATA_DIR}" ] || die "LLVM_PROFDATA_DIR (${LLVM_PROFDATA_DIR}) exists and is not a directory")
 
 export DEBUG=1
-export CXX='clang++'
+export _CXX='clang++'
 export CFLAGS='-fprofile-instr-generate -fcoverage-mapping'
 export LDFLAGS='-fprofile-instr-generate'
-#CFLAGS='-fprofile-arcs -ftest-coverage'
-#LDFLAGS='-fprofile-arcs -ftest-coverage'
 export LLVM_PROFILE_FILE="${LLVM_PROFDATA_DIR}/code-%p.profraw"
 
 rm -rf "./${LLVM_PROFDATA_DIR}" || die "Could not remove LLVM_PROFDATA_DIR (${LLVM_PROFDATA_DIR})"

--- a/tools/llvmcov.sh
+++ b/tools/llvmcov.sh
@@ -34,7 +34,7 @@ mkdir -p "${LLVM_PROFDATA_DIR}" || die "Could not create LLVM_PROFDATA_DIR (${LL
 make -sj unit_tests || die "Build failed"
 # shellcheck disable=SC2046
 llvm-profdata merge -output="${LLVM_PROFDATA_DIR}/code.profdata" $(find "${LLVM_PROFDATA_DIR}" -mindepth 1 -maxdepth 1 -type f -name 'code-*.profraw') || die "Could not merge prof data"
-llvm-cov report ./c2_unit_tests -instr-profile="${LLVM_PROFDATA_DIR}/code.profdata" -use-color || die "Could not generate coverage report"
+llvm-cov report -ignore-filename-regex='Catch2/src/catch2/' ./c2_unit_tests -instr-profile="${LLVM_PROFDATA_DIR}/code.profdata" -use-color || die "Could not generate coverage report"
 
 printf "Show entire coverage data in less pager (y/N): "
 read -r choice


### PR DESCRIPTION
Basically this works now:
- return 301 https://google.com;
- return 200 "Teststring\n";
- return 200 "Test string with spaces\n";

And this throws a config error:
- return 301 https://shgggeg.com (can't resolve domain)
- return 301 httpss://www.google.com (not a supported scheme)
- return 200 "blabla"hihgiog"; (parser error)

Also fixes some things to make it compile on the school PC, that's why 23 files changed lol