### PR TITLE
Fix and comment about checking send return value

### DIFF
--- a/src/HttpServer/CgiHandler.cpp
+++ b/src/HttpServer/CgiHandler.cpp
@@ -142,6 +142,7 @@ bool CgiHandler::processCGIResponse(const string& response, int clientSocket) {
 	}
 
 	fullResponse << headers << "\r\n\r\n" << body;
+	// TODO: @sonia: eval sheet says we HAVE to check send for < 0 and == 0, not sure what to do here :/
 	send(clientSocket, fullResponse.str().c_str(), fullResponse.str().length(), 0);
 	return true;
 }

--- a/src/HttpServer/GetRequestHandling.cpp
+++ b/src/HttpServer/GetRequestHandling.cpp
@@ -8,6 +8,7 @@ void HttpServer::redirectClient(int clientSocket, const string& newUri, int stat
 			<< "Connection: close\r\n\r\n";
 	string responseStr = response.str();
 	send(clientSocket, responseStr.c_str(), responseStr.length(), 0);
+	// not checking for <= 0 since we remove the client anyways
 	removeClient(clientSocket);
 }
 

--- a/src/HttpServer/ResponseSending.cpp
+++ b/src/HttpServer/ResponseSending.cpp
@@ -31,7 +31,7 @@ void HttpServer::terminateIfNoPendingData(PendingWrites::iterator& it, int clien
 	pw.bytesSent += static_cast<size_t>(bytesSent);
 	
 	// Check whether we've sent everything
-	if (pw.bytesSent >= pw.data.length()) {
+	if (pw.bytesSent >= pw.data.length() || bytesSent == 0) {
 		_pendingWrites.erase(it);
 		// for POLL: remove POLLOUT from events since we're done writing
 		stopMonitoringForWriteEvents(_monitorFds, clientSocket);


### PR DESCRIPTION
From the eval sheet:
Search for all read/recv/write/send and check if the returned value is correctly checked (checking only -1 or 0 values is not enough, both should be checked).

We do that mostly, but not completely, see diff.