### PR TITLE
Fix max body size limit handling

### DIFF
--- a/src/HttpServer/HttpServer.hpp
+++ b/src/HttpServer/HttpServer.hpp
@@ -103,6 +103,7 @@ public:
 		bool				chunkedTransfer;
 		size_t				bytesRead;
 		string				temporaryBuffer;
+		bool				pathParsed;
 
 		HttpRequest() :
 			method(),
@@ -114,7 +115,8 @@ public:
 			contentLength(0),
 			chunkedTransfer(false),
 			bytesRead(0),
-			temporaryBuffer() {}
+			temporaryBuffer(),
+			pathParsed(false) {}
 	};
 	
 	struct Server { // Basically just a thin wrapper around ServerCtx, but with some fields transformed for ease of use and efficiency

--- a/src/Repr.hpp
+++ b/src/Repr.hpp
@@ -246,7 +246,7 @@ struct in_port_t_helper {
 #include "HttpServer.hpp"
 POST_REFLECT_MEMBER(HttpServer::Server, struct in_addr, ip, struct in_port_t_helper, port, vector<string>, serverNames, Directives, directives, LocationCtxs, locations);
 POST_REFLECT_MEMBER(HttpServer::CgiProcess, pid_t, pid, int, readFd, string, response, unsigned long, totalSize, int, clientSocket, const LocationCtx*, location, bool, headersSent, std::time_t, lastActive);
-POST_REFLECT_MEMBER(HttpServer::HttpRequest, string, method, string, path, string, httpVersion, HttpServer::Headers, headers, string, body, HttpServer::RequestState, state, size_t, contentLength, bool, chunkedTransfer, size_t, bytesRead, string, temporaryBuffer);
+POST_REFLECT_MEMBER(HttpServer::HttpRequest, string, method, string, path, string, httpVersion, HttpServer::Headers, headers, string, body, HttpServer::RequestState, state, size_t, contentLength, bool, chunkedTransfer, size_t, bytesRead, string, temporaryBuffer, bool, pathParsed);
 POST_REFLECT_MEMBER(HttpServer::MultPlexFds, MultPlexType, multPlexType, HttpServer::SelectFds, selectFds, HttpServer::PollFds, pollFds, HttpServer::EpollFds, epollFds, HttpServer::FdStates, fdStates);
 POST_REFLECT_GETTER(HttpServer, HttpServer::MultPlexFds, _monitorFds, HttpServer::ClientFdToCgiMap, _clientToCgi, HttpServer::CgiFdToClientMap, _cgiToClient, vector<int>, _listeningSockets, HttpServer::PollFds, _pollFds, string, _httpVersionString, string, _rawConfig, Config, _config, HttpServer::MimeTypes, _mimeTypes, HttpServer::StatusTexts, _statusTexts, HttpServer::PendingWriteMap, _pendingWrites, HttpServer::PendingCloses, _pendingCloses, HttpServer::Servers, _servers, HttpServer::DefaultServers, _defaultServers, HttpServer::PendingRequests, _pendingRequests);
 


### PR DESCRIPTION
Fixed the logic for max body size handling.
Test with
```bash
curl -X PUT -H "Host: file_upload" 0:8000/qux -d "$(</dev/urandom tr -d \\0 | head -c $((1024)))"
```
replace 1024 with whatever size you wish, simple arithmetic is allowed (i.e. `$((1024 * 1024))`)