### PR TITLE
Add support for chunked transfer encoding

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -11,16 +11,16 @@
 #include "Utils.hpp"
 
 // clang-format off
-const string &Logger::fatalPrefix = "[ " + ansi::redBg("FATAL") + "  ] ";
-const string &Logger::errorPrefix = "[ " + ansi::red("ERROR") + "  ] ";
-const string &Logger::warningPrefix = "[ " + ansi::yellow("WARNING") + "   ] ";
-const string &Logger::infoPrefix = "[ " + ansi::white("INFO") + "   ] ";
-const string &Logger::debugPrefix = "[ " + ansi::rgbP("DEBUG", 146, 131, 116) + "  ] ";
-const string &Logger::tracePrefix = "[ " + ansi::rgbP("TRACE", 111, 97, 91) + "  ] ";
-const string &Logger::trace2Prefix = "[ " + ansi::rgbP("TRACE2", 111, 97, 91) + " ] "; // print full objects on construction/destruction
-const string &Logger::trace3Prefix = "[ " + ansi::rgbP("TRACE3", 111, 97, 91) + " ] "; // print object parameters as keyword-arguments
-const string &Logger::trace4Prefix = "[ " + ansi::rgbP("TRACE4", 111, 97, 91) + " ] "; // print aggregrate types verbosely with std:: prefix any everything
-const string &Logger::trace5Prefix = "[ " + ansi::rgbP("TRACE5", 111, 97, 91) + " ] "; // print as json (no color)
+const string &Logger::fatalPrefix = "[ " + ansi::redBg("FATAL") + "   ] ";
+const string &Logger::errorPrefix = "[ " + ansi::red("ERROR") + "   ] ";
+const string &Logger::warningPrefix = "[ " + ansi::yellow("WARNING") + " ] ";
+const string &Logger::infoPrefix = "[ " + ansi::white("INFO") + "    ] ";
+const string &Logger::debugPrefix = "[ " + ansi::rgbP("DEBUG", 146, 131, 116) + "   ] ";
+const string &Logger::tracePrefix = "[ " + ansi::rgbP("TRACE", 111, 97, 91) + "   ] ";
+const string &Logger::trace2Prefix = "[ " + ansi::rgbP("TRACE2", 111, 97, 91) + "  ] "; // print full objects on construction/destruction
+const string &Logger::trace3Prefix = "[ " + ansi::rgbP("TRACE3", 111, 97, 91) + "  ] "; // print object parameters as keyword-arguments
+const string &Logger::trace4Prefix = "[ " + ansi::rgbP("TRACE4", 111, 97, 91) + "  ] "; // print aggregrate types verbosely with std:: prefix any everything
+const string &Logger::trace5Prefix = "[ " + ansi::rgbP("TRACE5", 111, 97, 91) + "  ] "; // print as json (no color)
 // clang-format on
 
 Logger::Logger(std::ostream &_os, Level _logLevel)

--- a/src/Repr.hpp
+++ b/src/Repr.hpp
@@ -625,9 +625,6 @@ template <> struct ReprWrapper<MultPlexType> {
         case Constants::EPOLL:
             oss << "EPOLL";
             break;
-        default:
-            oss << "UNKNOWN";
-            break;
         }
         if (Logger::lastInstance().istrace5())
             return Utils::jsonEscape(oss.str());
@@ -653,9 +650,6 @@ template <> struct ReprWrapper<HttpServer::RequestState> {
         case HttpServer::REQUEST_ERROR:
             oss << "REQUEST_ERROR";
             break;
-        default:
-            oss << "UNKNOWN_STATE";
-            break;
         }
         if (Logger::lastInstance().istrace5())
             return Utils::jsonEscape(oss.str());
@@ -678,8 +672,24 @@ template <> struct ReprWrapper<HttpServer::FdState> {
         case HttpServer::FD_OTHER_STATE:
             oss << "OTHER_STATE";
             break;
-        default:
-            oss << "UNKNOWN_STATE";
+        }
+        if (Logger::lastInstance().istrace5())
+            return Utils::jsonEscape(oss.str());
+        else
+            return num(oss.str());
+    }
+};
+
+// for enum ChunkParsingState
+template <> struct ReprWrapper<HttpServer::ChunkParsingState> {
+    static inline string repr(const HttpServer::ChunkParsingState &value) {
+        std::ostringstream oss;
+        switch (value) {
+        case HttpServer::PARSE_CHUNK:
+            oss << "PARSE_CHUNK";
+            break;
+        case HttpServer::PARSE_CHUNK_SIZE:
+            oss << "PARSE_CHUNK_SIZE";
             break;
         }
         if (Logger::lastInstance().istrace5())
@@ -711,9 +721,6 @@ template <> struct ReprWrapper<TokenType> {
             break;
         case TOK_UNKNOWN:
             oss << "TOK_UNKNOWN";
-            break;
-        default:
-            oss << "UNKNOWN_TOKEN";
             break;
         }
         if (Logger::lastInstance().istrace5())

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -226,3 +226,12 @@ string Utils::formatSI(size_t size) {
     Logger::lastInstance().debug() << "Converting number " << repr(size) << " to readable SI Units " << repr(oss.str()) << std::endl;
     return oss.str();
 }
+
+size_t Utils::hexToSize(string sizeStr) {
+    size_t s;
+    std::stringstream ss;
+    ss << std::hex << sizeStr;
+    ss >> s;
+    Logger::lastInstance().trace() << "Converting " << repr(sizeStr) << " to size_t: " << repr(s) << std::endl;
+    return s;
+}

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -50,6 +50,7 @@ namespace Utils {
     string formattedTimestamp(std::time_t _t = 0, bool forLogger = false);
     string millisecondRemainderSinceEpoch();
     string formatSI(size_t size);
+    size_t hexToSize(string sizeStr);
 
     template <typename T> static inline vector<T> &getTmpVec() {
         static vector<T> _;


### PR DESCRIPTION
# Adds support for request with the header `Transfer-Encoding: chunked`
- works quite well, wasn't suuuuper hard, but required on carefully designed recursive function
- code is somewhat ugly, but not a lot of code so OKAY I guess
- not going with RFC (leaving out stuff such as "extension" and "trailer sections"). We only care about the data
- tests done with curl -T -> works
- bail out if anticipated chunk size exceeds allowed client max body size ✅