### PR TITLE
Add Keep alive

### DIFF
--- a/src/HttpServer/AddingClientSockets.cpp
+++ b/src/HttpServer/AddingClientSockets.cpp
@@ -57,6 +57,10 @@ void HttpServer::addNewClient(int listeningSocket) {
     }
 
     addClientSocketToMonitorFds(_monitorFds, clientSocket);
+    if (!persistConns.insert(std::make_pair(clientSocket, std::time(NULL))).second) {
+        log.error() << "New client socket " << repr(clientSocket) << " is already in persistent connections map, this should never happen"
+                    << std::endl;
+    }
     log.info();
     if (!ansi::noColor())
         log.info << ANSI_BLACK ANSI_GREEN_BG;

--- a/src/HttpServer/EventMonitoring.cpp
+++ b/src/HttpServer/EventMonitoring.cpp
@@ -76,7 +76,7 @@ HttpServer::MultPlexFds HttpServer::determineRemoteClients(const MultPlexFds &m,
     default:
         throw std::logic_error("Filtering remote clients from unknown multiplex FDs is not implemented");
     }
-    log.trace() << "Remove clients are " << repr(remaining) << std::endl;
+    log.trace() << "Remote clients are " << repr(remaining) << std::endl;
     return remaining;
 }
 

--- a/src/HttpServer/GetRequestHandling.cpp
+++ b/src/HttpServer/GetRequestHandling.cpp
@@ -15,7 +15,7 @@ void HttpServer::redirectClient(int clientSocket, const string &newUri, int stat
     std::ostringstream response;
     response << _httpVersionString << " " << statusCode << " " << statusTextFromCode(statusCode) << "\r\n"
              << "Location: " << newUri << "\r\n"
-             << "Connection: close\r\n\r\n";
+             << "Connection: keep-alive\r\n\r\n";
     string responseStr = response.str();
     log.debug() << "Sending redirection response immediately using " << func("send") << punct("()") << std::endl;
     log.trace() << "Full response (" << repr(responseStr.length()) << " bytes): " << repr(responseStr) << std::endl;

--- a/src/HttpServer/HttpServer.cpp
+++ b/src/HttpServer/HttpServer.cpp
@@ -46,7 +46,7 @@ HttpServer::HttpServer(const string &configPath, Logger &_log, size_t onlyCheckC
     : _monitorFds(Constants::defaultMultPlexType), _clientToCgi(), _cgiToClient(), _listeningSockets(),
       _httpVersionString(Constants::httpVersionString), _rawConfig(removeComments(readConfig(configPath))),
       _config(parseConfig(_rawConfig)), _mimeTypes(), _statusTexts(), _pendingWrites(), _pendingCloses(), _servers(), _defaultServers(),
-      _pendingRequests(), _tmpCgiFds(), log(_log) {
+      _pendingRequests(), _tmpCgiFds(), persistConns(), log(_log) {
     TRACE_ARG_CTOR(const string &, configPath);
     if (onlyCheckConfig > 0) {
         if (onlyCheckConfig > 1)

--- a/src/HttpServer/RemovingClientSockets.cpp
+++ b/src/HttpServer/RemovingClientSockets.cpp
@@ -37,6 +37,11 @@ void HttpServer::closeAndRemoveMultPlexFd(MultPlexFds &monitorFds, int fd) {
     bool isClientSocket = std::find(rawClientFds.begin(), rawClientFds.end(), fd) != rawClientFds.end();
     log.trace() << "Is FD " << repr(fd) << " a remote client FD?: " << repr(isClientSocket) << std::endl;
 
+    if (persistConns.count(fd) > 0) {
+        log.debug() << "Connection on FD " << repr(fd) << " has handled a response, but is persistent, therefore not closing" << std::endl;
+        return;
+    }
+
     Logger::StreamWrapper &out = isClientSocket ? log.info : log.debug;
 
     out();
@@ -87,8 +92,4 @@ void HttpServer::closeAndRemoveAllMultPlexFd(MultPlexFds &monitorFds) {
     }
 }
 
-void HttpServer::removeClient(int clientSocket) {
-    // TODO: @all: this function should actually be the one that removes all
-    // PendingWrites, PendingCloses, PendingRequests, cgi stuff
-    closeAndRemoveMultPlexFd(_monitorFds, clientSocket);
-}
+void HttpServer::removeClient(int clientSocket) { closeAndRemoveMultPlexFd(_monitorFds, clientSocket); }

--- a/src/HttpServer/ResponseSending.cpp
+++ b/src/HttpServer/ResponseSending.cpp
@@ -166,7 +166,7 @@ bool HttpServer::sendFileContent(int clientSocket, const string &filePath, const
     headers << _httpVersionString << " " << statusCode << " " << statusTextFromCode(statusCode) << "\r\n"
             << "Content-Length: " << fileSize << "\r\n"
             << "Content-Type: " << (contentType.empty() ? getMimeType(filePath) : contentType) << "\r\n"
-            << "Connection: close\r\n\r\n";
+            << "Connection: keep-alive\r\n\r\n";
 
     queueWrite(clientSocket, headers.str());
 
@@ -251,7 +251,7 @@ void HttpServer::sendString(int clientSocket, const string &payload, int statusC
     response << _httpVersionString << " " << statusCode << " " << statusTextFromCode(statusCode) << "\r\n"
              << "Content-Type: " << contentType << "\r\n"
              << "Content-Length: " << payload.length() << "\r\n"
-             << "Connection: close\r\n"
+             << "Connection: keep-alive\r\n"
              << "\r\n";
     if (!onlyHeaders) {
         log.debug() << "Queueing actual string payload, since it's not a HEAD request" << std::endl;

--- a/test/unit_tests/Utils_parseArgs_tests.cpp
+++ b/test/unit_tests/Utils_parseArgs_tests.cpp
@@ -13,97 +13,97 @@ using namespace Catch::Matchers;
 
 // positive tests
 TEST_CASE("0 arguments", "[utils][argparse]") {
-  int argc = 1;
-  const char *argv_[] = {"./webserv", NULL};
-  char **argv = (char **)argv_;
+    int argc = 1;
+    const char *argv_[] = {"./webserv", NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK(Utils::parseArgs(argc, argv) == Constants::defaultConfPath);
+    CHECK(Utils::parseArgs(argc, argv) == Constants::defaultConfPath);
 }
 
 TEST_CASE("0 arguments and corrupted argv", "[utils][argparse]") {
-  int argc = 1;
-  const char **argv_ = NULL;
-  char **argv = (char **)argv_;
+    int argc = 1;
+    const char **argv_ = NULL;
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK(Utils::parseArgs(argc, argv) == Constants::defaultConfPath);
+    CHECK(Utils::parseArgs(argc, argv) == Constants::defaultConfPath);
 }
 
 TEST_CASE("1 argument", "[utils][argparse]") {
-  int argc = 2;
-  const char *argv_[] = {"./webserv", "whatever", NULL};
-  char **argv = (char **)argv_;
+    int argc = 2;
+    const char *argv_[] = {"./webserv", "whatever", NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK(Utils::parseArgs(argc, argv) == "whatever");
+    CHECK(Utils::parseArgs(argc, argv) == "whatever");
 }
 
 TEST_CASE("1 empty argument", "[utils][argparse]") {
-  int argc = 2;
-  const char *argv_[] = {"./webserv", "", NULL};
-  char **argv = (char **)argv_;
+    int argc = 2;
+    const char *argv_[] = {"./webserv", "", NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK(Utils::parseArgs(argc, argv) == "");
+    CHECK(Utils::parseArgs(argc, argv) == "");
 }
 
 // negative tests
 TEST_CASE("null argv: ac = 2 and argv = NULL", "[utils][argparse]") {
-  int argc = 2;
-  const char **argv_ = NULL;
-  char **argv = (char **)argv_;
+    int argc = 2;
+    const char **argv_ = NULL;
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
-  CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGV_NULL_MSG));
+    CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
+    CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGV_NULL_MSG));
 }
 
 TEST_CASE("corrupted argv: ac = 2 and argv = {NULL}", "[utils][argparse]") {
-  int argc = 2;
-  const char *argv_[] = {NULL};
-  char **argv = (char **)argv_;
+    int argc = 2;
+    const char *argv_[] = {NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
-  CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGV_CORRUPT_MSG));
+    CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
+    CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGV_CORRUPT_MSG));
 }
 
 TEST_CASE("corrupted argv: ac = 2 and argv = {\"./webserv\", NULL}", "[utils][argparse]") {
-  int argc = 2;
-  const char *argv_[] = {"./webserv", NULL};
-  char **argv = (char **)argv_;
+    int argc = 2;
+    const char *argv_[] = {"./webserv", NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
-  CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGV_CORRUPT_MSG));
+    CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
+    CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGV_CORRUPT_MSG));
 }
 
 TEST_CASE("argc very wrong: ac = 0 and argv = NULL", "[utils][argparse]") {
-  int argc = 0;
-  const char **argv_ = NULL;
-  char **argv = (char **)argv_;
+    int argc = 0;
+    const char **argv_ = NULL;
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
-  CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
+    CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
+    CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
 }
 
 TEST_CASE("argc very wrong: ac = 0", "[utils][argparse]") {
-  int argc = 0;
-  const char *argv_[] = {NULL};
-  char **argv = (char **)argv_;
+    int argc = 0;
+    const char *argv_[] = {NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
-  CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
+    CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
+    CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
 }
 
 TEST_CASE("argc wrong: 2 arguments (ac = 3)", "[utils][argparse]") {
-  int argc = 3;
-  const char *argv_[] = {"./webserv", "whatever", "another", NULL};
-  char **argv = (char **)argv_;
+    int argc = 3;
+    const char *argv_[] = {"./webserv", "whatever", "another", NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
-  CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
+    CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
+    CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
 }
 
 TEST_CASE("argc wrong: 3 argument (ac = 4)", "[utils][argparse]") {
-  int argc = 4;
-  const char *argv_[] = {"./webserv", "whatever", "another", "yet another", NULL};
-  char **argv = (char **)argv_;
+    int argc = 4;
+    const char *argv_[] = {"./webserv", "whatever", "another", "yet another", NULL};
+    char **argv = const_cast<char **>(argv_);
 
-  CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
-  CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
+    CHECK_THROWS_AS(Utils::parseArgs(argc, argv), std::runtime_error);
+    CHECK_THROWS_WITH(Utils::parseArgs(argc, argv), ContainsSubstring(ARGC_WRONG_MSG));
 }


### PR DESCRIPTION
- Yeah see last commit message. Basically works. Test with crazy stuff like
- `printf 'PUT /foo/a.txt HTTP/1.1\r\nHost: 0.0.0.0:8008\r\nContent-Length: 5\r\n\r\ndata\n' | nc 0 8008`
- followed by multiple repetitions
- `curl 0:8008/uploads/stuff.txt 0:8008/uploads/a.txt 0:8008/uploads/a.txt -: -H "Transfer-Encoding: chunked" 0:8008/foo/stuff.txt -T.`


Also btw stress tested the heck outta webserv with locust with many thousands concurrent connections, handles it well until a certain threshold